### PR TITLE
[개선] Delete Reply 로직 개선 (2022.11.08 윤희승)

### DIFF
--- a/src/main/java/com/FlagHome/backend/v1/reply/repository/ReplyRepositoryCustom.java
+++ b/src/main/java/com/FlagHome/backend/v1/reply/repository/ReplyRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface ReplyRepositoryCustom {
     List<Reply> findByPostId(long postId);
+    List<Reply> findByPostIdAndReplyGroup(long postId, long replyGroup);
 }

--- a/src/main/java/com/FlagHome/backend/v1/reply/repository/ReplyRepositoryImpl.java
+++ b/src/main/java/com/FlagHome/backend/v1/reply/repository/ReplyRepositoryImpl.java
@@ -19,4 +19,13 @@ public class ReplyRepositoryImpl implements ReplyRepositoryCustom{
                 .where(reply.post.id.eq(postId))
                 .fetch();
     }
+
+    @Override
+    public List<Reply> findByPostIdAndReplyGroup(long postId, long replyGroup) {
+        return jpaQueryFactory
+                .selectFrom(reply)
+                .where(reply.post.id.eq(postId)
+                        .and(reply.replyGroup.eq(replyGroup)))
+                .fetch();
+    }
 }


### PR DESCRIPTION
- Delete Reply의 경우
  * Depth가 0이면 ChildReply까지 모두 제거
  * Depth가 0일때 제거되면 자신보다 Group이 큰 댓글의 Group 정렬
  * 자신보다 Order가 큰 댓글이 존재한다면 Order 정렬
- findByPostIdAndReplyGroup 메서드 추가