### PR TITLE
[추가, 개선] 관리자 기능 추가, 회원가입 개선 (#40, #58) (2022.12.28 문희조)

### DIFF
--- a/src/main/java/com/FlagHome/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/FlagHome/backend/domain/admin/controller/AdminController.java
@@ -1,0 +1,39 @@
+package com.FlagHome.backend.domain.admin.controller;
+
+import com.FlagHome.backend.domain.admin.dto.ApproveSignUpRequest;
+import com.FlagHome.backend.domain.admin.service.AdminService;
+import com.FlagHome.backend.domain.auth.entity.AuthMember;
+import com.FlagHome.backend.domain.auth.service.AuthMemberService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+    private final AdminService adminService;
+
+    @GetMapping("/approval")
+    @ApiOperation(value = "가입 승인이 필요한 리스트 가져오기", notes = "재학생 메일 인증을 수행한 동아리원 가입 요청 리스트")
+    public ResponseEntity<List<AuthMember>> getAllNeedApprovals() {
+        return ResponseEntity.ok(adminService.getAllAuthorizedAuthMember());
+    }
+
+    @PostMapping("/approval")
+    @ApiOperation(value = "회원가입 승인", notes = "동아리원 정보 암호화 후 DB에 저장, 인증 정보 삭제")
+    public ResponseEntity<Void> approveAuthMember(@RequestBody ApproveSignUpRequest approveSignUpRequest) {
+        adminService.approveAuthMember(approveSignUpRequest.getId());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{auth_Id}")
+    @ApiOperation(value = "회원가입 거부", notes = "인증 정보를 삭제")
+    public ResponseEntity<Void> deleteAuthMember(@PathVariable(name = "auth_id") long authMemberId) {
+        adminService.deleteAuthMember(authMemberId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/FlagHome/backend/domain/admin/dto/ApproveSignUpRequest.java
+++ b/src/main/java/com/FlagHome/backend/domain/admin/dto/ApproveSignUpRequest.java
@@ -1,0 +1,14 @@
+package com.FlagHome.backend.domain.admin.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApproveSignUpRequest {
+    @ApiModelProperty(value = "인증 정보 ID")
+    private long id;
+}

--- a/src/main/java/com/FlagHome/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/FlagHome/backend/domain/admin/service/AdminService.java
@@ -1,0 +1,40 @@
+package com.FlagHome.backend.domain.admin.service;
+
+import com.FlagHome.backend.domain.auth.entity.AuthMember;
+import com.FlagHome.backend.domain.auth.repository.AuthRepository;
+import com.FlagHome.backend.domain.member.entity.Member;
+import com.FlagHome.backend.domain.member.repository.MemberRepository;
+import com.FlagHome.backend.global.exception.CustomException;
+import com.FlagHome.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+    private final MemberRepository memberRepository;
+    private final AuthRepository authRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public List<AuthMember> getAllAuthorizedAuthMember() {
+        return authRepository.getAllAuthorizedAuthMember();
+    }
+
+    @Transactional
+    public void approveAuthMember(Long authMemberId) {
+        AuthMember authMember = authRepository.findById(authMemberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_TARGET_NOT_FOUND));
+
+        memberRepository.save(Member.of(authMember, passwordEncoder));
+        deleteAuthMember(authMemberId);
+    }
+
+    @Transactional
+    public void deleteAuthMember(Long authMemberId) {
+        authRepository.deleteById(authMemberId);
+    }
+}

--- a/src/main/java/com/FlagHome/backend/domain/auth/JoinType.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/JoinType.java
@@ -1,0 +1,10 @@
+package com.FlagHome.backend.domain.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JoinType {
+    NORMAL, CLUB
+}

--- a/src/main/java/com/FlagHome/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/controller/AuthController.java
@@ -39,14 +39,14 @@ public class AuthController {
     }
 
     @PostMapping("/signup")
-    @ApiOperation(value = "회원가입", notes = "메일인증 완료 시 회원가입")
+    @ApiOperation(value = "회원가입", notes = "메일 인증 완료 시 회원가입 처리, 가입 구분에 따라 다름")
     public ResponseEntity<SignUpResponse> signup(@RequestBody SignUpRequest signUpRequest) {
         return ResponseEntity.ok(authService.signUp(signUpRequest));
     }
 
     @PostMapping("/login")
     @ApiOperation(value = "로그인")
-    public ResponseEntity<TokenResponse> logIn(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest loginRequest) {
         return ResponseEntity.ok(authService.login(loginRequest));
     }
 

--- a/src/main/java/com/FlagHome/backend/domain/auth/dto/JoinRequest.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/dto/JoinRequest.java
@@ -1,16 +1,12 @@
 package com.FlagHome.backend.domain.auth.dto;
 
-import com.FlagHome.backend.domain.Status;
-import com.FlagHome.backend.domain.auth.entity.AuthMember;
+import com.FlagHome.backend.domain.auth.JoinType;
 import com.FlagHome.backend.domain.member.Major;
-import com.FlagHome.backend.domain.member.Role;
-import com.FlagHome.backend.domain.member.entity.Member;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Builder
@@ -34,4 +30,7 @@ public class JoinRequest {
 
     @ApiModelProperty(example = "19017041")
     private String studentId;
+
+    @ApiModelProperty(value = "유저 가입 구분", notes = "일반 유저 : NORMAL, 동아리원 : CLUB")
+    private JoinType joinType;
 }

--- a/src/main/java/com/FlagHome/backend/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/dto/LoginRequest.java
@@ -13,12 +13,12 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 @AllArgsConstructor
 public class LoginRequest {
     @ApiModelProperty(example = "gmlwh124")
-    private String loginID;
+    private String loginId;
 
     @ApiModelProperty(example = "1234")
     private String password;
 
     public UsernamePasswordAuthenticationToken toAuthentication() {
-        return new UsernamePasswordAuthenticationToken(loginID, password);
+        return new UsernamePasswordAuthenticationToken(loginId, password);
     }
 }

--- a/src/main/java/com/FlagHome/backend/domain/auth/dto/SignUpResponse.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/dto/SignUpResponse.java
@@ -1,5 +1,6 @@
 package com.FlagHome.backend.domain.auth.dto;
 
+import com.FlagHome.backend.domain.auth.JoinType;
 import com.FlagHome.backend.domain.auth.entity.AuthMember;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,10 @@ public class SignUpResponse {
     @ApiModelProperty(value = "이메일", notes = "회원가입 정보에 적은 이메일")
     private String email;
 
-    public static SignUpResponse of(AuthMember authMember) {
-        return new SignUpResponse(authMember.getLoginId(), authMember.getEmail());
+    @ApiModelProperty(value = "유저 가입 구분")
+    private JoinType joinType;
+
+    public static SignUpResponse from(AuthMember authMember) {
+        return new SignUpResponse(authMember.getLoginId(), authMember.getEmail(), authMember.getJoinType());
     }
 }

--- a/src/main/java/com/FlagHome/backend/domain/auth/entity/AuthMember.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/entity/AuthMember.java
@@ -1,6 +1,7 @@
 package com.FlagHome.backend.domain.auth.entity;
 
 import com.FlagHome.backend.domain.Status;
+import com.FlagHome.backend.domain.auth.JoinType;
 import com.FlagHome.backend.domain.auth.dto.JoinRequest;
 import com.FlagHome.backend.domain.member.Major;
 import com.FlagHome.backend.domain.member.Role;
@@ -42,6 +43,13 @@ public class AuthMember {
     @Enumerated(value = EnumType.STRING)
     private Major major;
 
+    @Column(name = "join_type")
+    @Enumerated(value = EnumType.STRING)
+    private JoinType joinType;
+
+    @Column
+    private boolean isAuthorizedClubMember;
+
     @Column
     private String certification;
 
@@ -56,8 +64,14 @@ public class AuthMember {
                 .email(joinRequest.getEmail())
                 .major(joinRequest.getMajor())
                 .studentId(joinRequest.getStudentId())
+                .joinType(joinRequest.getJoinType())
+                .isAuthorizedClubMember(false)
                 .certification(certification)
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    public void updateAuthorizedTrue() {
+        this.isAuthorizedClubMember = true;
     }
 }

--- a/src/main/java/com/FlagHome/backend/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/repository/AuthRepository.java
@@ -9,4 +9,8 @@ import java.util.Optional;
 @Repository
 public interface AuthRepository extends JpaRepository<AuthMember, Long>, AuthRepositoryCustom {
     Optional<AuthMember> findByEmail(String email);
+
+    Optional<AuthMember> findById(Long authMemberId);
+
+    void deleteById(Long authMemberId);
 }

--- a/src/main/java/com/FlagHome/backend/domain/auth/repository/AuthRepositoryCustom.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/repository/AuthRepositoryCustom.java
@@ -7,7 +7,9 @@ import java.util.List;
 
 @Repository
 public interface AuthRepositoryCustom {
-    List<AuthMember> findAllNotProceedAuthMember();
+    List<AuthMember> getAllNotProceedAuthMember();
 
-    void deleteNotProceedAuthMember(List<AuthMember> authMemberList);
+    List<AuthMember> getAllAuthorizedAuthMember();
+
+    void deleteAllNotProceedAuthMember(List<AuthMember> authMemberList);
 }

--- a/src/main/java/com/FlagHome/backend/domain/auth/repository/AuthRepositoryImpl.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/repository/AuthRepositoryImpl.java
@@ -16,16 +16,24 @@ public class AuthRepositoryImpl implements AuthRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<AuthMember> findAllNotProceedAuthMember() {
+    public List<AuthMember> getAllNotProceedAuthMember() {
         return queryFactory
                 .selectFrom(authMember)
-                .where(authMember.createdAt
-                        .before(LocalDateTime.now().minusMinutes(10)))
+                .where(authMember.createdAt.before(LocalDateTime.now().minusMinutes(10)),
+                        authMember.isAuthorizedClubMember.eq(false))
                 .fetch();
     }
 
     @Override
-    public void deleteNotProceedAuthMember(List<AuthMember> authMemberList) {
+    public List<AuthMember> getAllAuthorizedAuthMember() {
+        return queryFactory
+                .selectFrom(authMember)
+                .where(authMember.isAuthorizedClubMember.eq(true))
+                .fetch();
+    }
+
+    @Override
+    public void deleteAllNotProceedAuthMember(List<AuthMember> authMemberList) {
         for (AuthMember unAuthMember : authMemberList) {
             queryFactory
                     .delete(authMember)

--- a/src/main/java/com/FlagHome/backend/domain/auth/service/AuthMemberService.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/service/AuthMemberService.java
@@ -21,10 +21,10 @@ public class AuthMemberService {
     @Transactional
     public void deleteNotProceedAuthMember() {
         List<AuthMember> unAuthMemberList = findAllNotProceedAuthMember();
-        authRepository.deleteNotProceedAuthMember(unAuthMemberList);
+        authRepository.deleteAllNotProceedAuthMember(unAuthMemberList);
     }
 
     private List<AuthMember> findAllNotProceedAuthMember() {
-        return authRepository.findAllNotProceedAuthMember();
+        return authRepository.getAllNotProceedAuthMember();
     }
 }

--- a/src/main/java/com/FlagHome/backend/domain/auth/service/CustomUserDetailService.java
+++ b/src/main/java/com/FlagHome/backend/domain/auth/service/CustomUserDetailService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         return memberRepository.findByLoginId(loginId)
                 .map(this::createUserDetails)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다 : " + loginId));
     }
 
     private UserDetails createUserDetails(Member member) {

--- a/src/main/java/com/FlagHome/backend/domain/mail/dto/MailRequest.java
+++ b/src/main/java/com/FlagHome/backend/domain/mail/dto/MailRequest.java
@@ -29,7 +29,7 @@ public class MailRequest {
                         .withHtml(createContent(this.content)));
 
         return new SendEmailRequest()
-                .withSource(FROM)
+                .withSource("gmlwh124@naver.com")
                 .withDestination(destination)
                 .withMessage(message);
     }

--- a/src/main/java/com/FlagHome/backend/domain/member/Role.java
+++ b/src/main/java/com/FlagHome/backend/domain/member/Role.java
@@ -1,10 +1,21 @@
 package com.FlagHome.backend.domain.member;
 
+import com.FlagHome.backend.domain.auth.JoinType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum Role {
-    ROLE_USER, ROLE_ADMIN
+    ROLE_USER, ROLE_CLUB, ROLE_ADMIN
+    ;
+
+    /**
+     * JoinTpye에 맞는 권한을 리턴 (Casting이 일어날 일이 없어 NPE가 발생 X - 삼항 연산자로 구현)
+     * @param joinType
+     * @return 유저 권한
+     */
+    public static Role getRole(JoinType joinType) {
+        return joinType == JoinType.CLUB ? ROLE_CLUB : ROLE_USER;
+    }
 }

--- a/src/main/java/com/FlagHome/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/FlagHome/backend/domain/member/controller/MemberController.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
-    // 활동, 잔디 기능 필요!!
-    @GetMapping("/{id}")
-    @ApiOperation(value = "멤버 정보 보기")
-    public ResponseEntity<Void> getProfile(@RequestParam long id) {
-
-        return ResponseEntity.ok().build();
-    }
+//     활동, 잔디 기능 필요!!
+//    @GetMapping("/{id}")
+//    @ApiOperation(value = "멤버 정보 보기")
+//    public ResponseEntity<Void> getProfile() {
+//
+//        return ResponseEntity.ok().build();
+//    }
 
     @PostMapping("/find-id")
     @ApiOperation(value = "아이디 찾기", notes = "요청 시 아이디를 찾아서 메일로 전송")

--- a/src/main/java/com/FlagHome/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/FlagHome/backend/domain/member/entity/Member.java
@@ -73,7 +73,7 @@ public class Member extends BaseEntity {
                 .bio(" ")
                 .phoneNumber(" ")
                 .profileImg("default")
-                .role(Role.ROLE_USER)
+                .role(Role.getRole(authMember.getJoinType()))
                 .status(Status.GENERAL)
                 .build();
     }

--- a/src/main/java/com/FlagHome/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/FlagHome/backend/domain/member/service/MemberService.java
@@ -39,7 +39,7 @@ public class MemberService {
         Member member = findMemberByEmail(email);
 
         if (!StringUtils.equals(member.getName(), name)) {
-            throw new CustomException(ErrorCode.NAME_EMAIL_NOT_MATCH);
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
 
         sendFindIdResult(member.getLoginId(), email);
@@ -55,7 +55,7 @@ public class MemberService {
         Member member = findMemberByEmail(email);
 
         if (!StringUtils.equals(member.getLoginId(), loginId)) {
-            throw new CustomException(ErrorCode.ID_EMAIL_NOT_MATCH);
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
 
         String newPassword = RandomGenerator.getRandomPassword();

--- a/src/main/java/com/FlagHome/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/FlagHome/backend/global/exception/ErrorCode.java
@@ -16,8 +16,6 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않는 토큰입니다."),
     TOKEN_NOT_MATCH(HttpStatus.BAD_REQUEST, "토큰의 정보가 일치하지 않습니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    NAME_EMAIL_NOT_MATCH(HttpStatus.BAD_REQUEST, "이메일과 일치하지 않는 이름입니다."),
-    ID_EMAIL_NOT_MATCH(HttpStatus.BAD_REQUEST, "이메일과 일치하지 않는 아이디입니다."),
     NOT_USW_EMAIL(HttpStatus.BAD_REQUEST, "수원대학교 웹 메일 주소가 아닙니다."),
     PASSWORD_IS_SAME(HttpStatus.BAD_REQUEST, "기존과 같은 비밀번호는 사용할 수 없습니다."),
     CATEGORY_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리 입니다."),

--- a/src/test/java/com/FlagHome/backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/com/FlagHome/backend/domain/auth/AuthServiceTest.java
@@ -1,15 +1,12 @@
 package com.FlagHome.backend.domain.auth;
 
-import com.FlagHome.backend.domain.auth.dto.JoinRequest;
 import com.FlagHome.backend.domain.auth.dto.LoginRequest;
-import com.FlagHome.backend.domain.auth.dto.SignUpResponse;
 import com.FlagHome.backend.domain.auth.service.AuthService;
-import com.FlagHome.backend.domain.member.Major;
 import com.FlagHome.backend.domain.member.Role;
 import com.FlagHome.backend.domain.member.entity.Member;
 import com.FlagHome.backend.domain.member.repository.MemberRepository;
+import com.FlagHome.backend.domain.token.dto.TokenRequest;
 import com.FlagHome.backend.domain.token.dto.TokenResponse;
-import com.FlagHome.backend.domain.token.service.RefreshTokenService;
 import com.FlagHome.backend.global.exception.CustomException;
 import com.FlagHome.backend.global.jwt.JwtUtilizer;
 import org.junit.jupiter.api.DisplayName;
@@ -22,20 +19,15 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest
 @Transactional
 public class AuthServiceTest {
-    private final String baseUri = "/api/auth";
     @Autowired
     private AuthService authService;
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private RefreshTokenService refreshTokenService;
 
     @Autowired
     private BCryptPasswordEncoder passwordEncoder;
@@ -141,95 +133,84 @@ public class AuthServiceTest {
 //
 //    }
 
-//    @Test
-//    @DisplayName("로그인 테스트")
-//    void loginTest() {
-//        // given
-//        String loginId = "gmlwh124";
-//        String password = "1234";
-//
-//        JoinRequest joinRequest = JoinRequest.builder()
-//                .loginId(loginId)
-//                .password(password)
-//                .name("문희조")
-//                .major(Major.컴퓨터SW)
-//                .studentId("19017041")
-//                .build();
-//
-//        Member signUpMember = joinRequest.toMember(passwordEncoder);
-//        memberRepository.saveAndFlush(signUpMember);
-//
-//        LoginRequest logInRequest = LoginRequest.builder()
-//                .loginID(loginId)
-//                .password(password)
-//                .build();
-//
-//        // when
-//        TokenResponse tokenResponse = authService.login(logInRequest);
-//
-//        // then : 정상적으로 발급되는 지, 유효한 지, 데이터가 일치하는 지
-//        assertThat(tokenResponse.getAccessToken()).isNotNull();
-//        assertThat(tokenResponse.getRefreshToken()).isNotNull();
-//        assertThat(tokenResponse.getAccessTokenExpiresIn()).isNotNull();
-//        assertThat(tokenResponse.getGrantType()).isEqualTo("Bearer");
-//
-//        String accessToken = tokenResponse.getAccessToken();
-//
-//        assertThat(jwtUtilizer.validateToken(accessToken)).isTrue();
-//
-//        Authentication authentication = jwtUtilizer.getAuthentication(accessToken);
-//        long memberId = Long.parseLong(authentication.getName());
-//        Member member = memberRepository.findByLoginId(loginId).get();
-//        assertThat(member.getId()).isEqualTo(memberId);
-//    }
+    @Test
+    @DisplayName("로그인 테스트")
+    void loginTest() {
+        // given
+        String loginId = "gmlwh124";
+        String password = "1234";
 
-//    @Test
-//    @DisplayName("토큰 재발급 테스트")
-//    void reIssueToken() {
-//        // given
-//        String loginId = "gmlwh124";
-//        String password = "1234";
-//
-//        JoinRequest joinRequest = JoinRequest.builder()
-//                .loginId(loginId)
-//                .password(password)
-//                .name("문희조")
-//                .major(Major.컴퓨터SW)
-//                .studentId("19017041")
-//                .build();
-//
-//        Member signUpMember =
-//                joinRequest.toMember(passwordEncoder);
-//        memberRepository.save(signUpMember);
-//
-//        LoginRequest logInRequest = LoginRequest.builder()
-//                .loginID(loginId)
-//                .password(password)
-//                .build();
-//
-//        TokenResponse tokenResponse = authService.login(logInRequest);
-//
-//        TokenRequest tokenRequest = TokenRequest.builder()
-//                .accessToken(tokenResponse.getAccessToken())
-//                .refreshToken(tokenResponse.getRefreshToken())
-//                .build();
-//
-//        // when
-//        TokenResponse reissueToken = authService.reissueToken(tokenRequest);
-//
-//        // then
-//        assertThat(reissueToken.getAccessToken()).isNotNull();
-//        assertThat(reissueToken.getRefreshToken()).isNotNull();
-//        assertThat(reissueToken.getGrantType()).isNotNull();
-//        assertThat(reissueToken.getAccessTokenExpiresIn()).isNotNull();
-//
-//        String accessToken = reissueToken.getAccessToken();
-//
-//        assertThat(jwtUtilizer.validateToken(accessToken)).isTrue();
-//
-//        Authentication authentication = jwtUtilizer.getAuthentication(accessToken);
-//        long memberId = Long.parseLong(authentication.getName());
-//        Member member = memberRepository.findByLoginId(loginId).get();
-//        assertThat(member.getId()).isEqualTo(memberId);
-//    }
+        memberRepository.saveAndFlush(Member.builder()
+                        .loginId(loginId)
+                        .password(passwordEncoder.encode(password))
+                        .role(Role.ROLE_USER)
+                        .build());
+
+        LoginRequest logInRequest = LoginRequest.builder()
+                .loginId(loginId)
+                .password(password)
+                .build();
+
+        // when
+        TokenResponse tokenResponse = authService.login(logInRequest);
+
+        // then : 정상적으로 발급되는 지, 유효한 지, 데이터가 일치하는 지
+        assertThat(tokenResponse.getAccessToken()).isNotNull();
+        assertThat(tokenResponse.getRefreshToken()).isNotNull();
+        assertThat(tokenResponse.getAccessTokenExpiresIn()).isNotNull();
+        assertThat(tokenResponse.getGrantType()).isEqualTo("Bearer");
+
+        String accessToken = tokenResponse.getAccessToken();
+
+        assertThat(jwtUtilizer.validateToken(accessToken)).isTrue();
+
+        Authentication authentication = jwtUtilizer.getAuthentication(accessToken);
+        long memberId = Long.parseLong(authentication.getName());
+        Member member = memberRepository.findByLoginId(loginId).get();
+        assertThat(member.getId()).isEqualTo(memberId);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 테스트")
+    void reIssueToken() {
+        // given
+        String loginId = "gmlwh124";
+        String password = "1234";
+
+        memberRepository.saveAndFlush(Member.builder()
+                        .loginId(loginId)
+                        .password(passwordEncoder.encode(password))
+                        .role(Role.ROLE_USER)
+                        .build());
+
+        LoginRequest logInRequest = LoginRequest.builder()
+                .loginId(loginId)
+                .password(password)
+                .build();
+
+        TokenResponse tokenResponse = authService.login(logInRequest);
+
+        TokenRequest tokenRequest = TokenRequest.builder()
+                .accessToken(tokenResponse.getAccessToken())
+                .refreshToken(tokenResponse.getRefreshToken())
+                .build();
+
+        // when
+        TokenResponse reissueToken = authService.reissueToken(tokenRequest);
+
+        // then
+        assertThat(reissueToken.getAccessToken()).isNotNull();
+        assertThat(reissueToken.getRefreshToken()).isNotNull();
+        assertThat(reissueToken.getGrantType()).isNotNull();
+        assertThat(reissueToken.getAccessTokenExpiresIn()).isNotNull();
+
+        String accessToken = reissueToken.getAccessToken();
+
+        assertThat(jwtUtilizer.validateToken(accessToken)).isTrue();
+
+        Authentication authentication = jwtUtilizer.getAuthentication(accessToken);
+        long memberId = Long.parseLong(authentication.getName());
+        Member member = memberRepository.findByLoginId(loginId).get();
+        assertThat(member.getId()).isEqualTo(memberId);
+    }
 }


### PR DESCRIPTION
 - 관리자 기능 추가 (가입 승인, 거부, 리스트 불러오기)
 - 새로운 역할 추가 (일반, 동아리원, 관리자)
 - 가입 구분에 따라 회원가입 구분 (동아리원 관리자 승인)
 - 자잘한 수정 (인증정보 칼럼 추가, Repo 로직 개선)