### PR TITLE
[추가, 수정] 중복 체크 DTO 추가, Member 검증 이동, 프론트 요구사항 반영 (23.05.18 문희조)

### DIFF
--- a/src/main/java/com/Flaground/backend/global/common/BaseEntity.java
+++ b/src/main/java/com/Flaground/backend/global/common/BaseEntity.java
@@ -11,18 +11,20 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
+
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
     @CreatedDate
     @Column(name="created_at", updatable = false)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Seoul")
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(name="updated_at")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Seoul")
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Seoul")
     private LocalDateTime updatedAt;
 
     public void updateModifiedDate() {

--- a/src/main/java/com/Flaground/backend/global/jwt/JwtUtilizer.java
+++ b/src/main/java/com/Flaground/backend/global/jwt/JwtUtilizer.java
@@ -48,7 +48,6 @@ public class JwtUtilizer {
         final Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
         final Date refreshTokenExpiresIn = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
 
-        // Access Token 생성
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())       // payload "sub": "name"
                 .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
@@ -56,18 +55,12 @@ public class JwtUtilizer {
                 .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
                 .compact();
 
-        // Refresh Token 생성
         String refreshToken = Jwts.builder()
                 .setExpiration(refreshTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
 
-        return TokenResponse.builder()
-                .grantType(BEARER_TYPE)
-                .accessToken(accessToken)
-                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
-                .refreshToken(refreshToken)
-                .build();
+        return tokenResponse(accessToken, accessTokenExpiresIn.getTime(), refreshToken);
     }
 
     public Authentication getAuthentication(String accessToken) {
@@ -115,5 +108,14 @@ public class JwtUtilizer {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
+    }
+
+    private TokenResponse tokenResponse(String accessToken, long accessTokenExpiresIn, String refreshToken) {
+        return TokenResponse.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn)
+                .refreshToken(refreshToken)
+                .build();
     }
 }

--- a/src/main/java/com/Flaground/backend/global/utility/RandomGenerator.java
+++ b/src/main/java/com/Flaground/backend/global/utility/RandomGenerator.java
@@ -1,19 +1,20 @@
 package com.Flaground.backend.global.utility;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import java.security.SecureRandom;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RandomGenerator {
     private static final SecureRandom RANDOM = new SecureRandom();
-
-    private RandomGenerator() { }
+    private static final int LENGTH = 6;
+    private static final int RANDOM_START = 48;
+    private static final int RANDOM_END = 58;
 
     public static String getRandomNumber() {
-        int length = 6;
-        int randomNumberStart = 48;
-        int randomNumberEnd = 57;
-
-        return RANDOM.ints(randomNumberStart, randomNumberEnd + 1)
-                .limit(length)
+        return RANDOM.ints(RANDOM_START, RANDOM_END)
+                .limit(LENGTH)
                 .collect(StringBuilder::new, StringBuilder::appendCodePoint,
                         StringBuilder::append)
                 .toString();

--- a/src/main/java/com/Flaground/backend/module/activity/controller/dto/response/ActivityResponse.java
+++ b/src/main/java/com/Flaground/backend/module/activity/controller/dto/response/ActivityResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ActivityResponse {
     private Long id;
     private String name;

--- a/src/main/java/com/Flaground/backend/module/activity/repository/ActivityRepositoryImpl.java
+++ b/src/main/java/com/Flaground/backend/module/activity/repository/ActivityRepositoryImpl.java
@@ -44,6 +44,7 @@ public class ActivityRepositoryImpl implements ActivityRepositoryCustom {
                 .from(activity)
                 .innerJoin(activity.leader, member)
                 .where(activity.status.eq(ActivityStatus.RECRUIT))
+                .limit(3)
                 .fetch();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/auth/controller/AuthController.java
+++ b/src/main/java/com/Flaground/backend/module/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.Flaground.backend.module.auth.controller;
 
 import com.Flaground.backend.global.common.ApplicationResponse;
 import com.Flaground.backend.module.auth.controller.dto.request.*;
+import com.Flaground.backend.module.auth.controller.dto.response.DuplicationResponse;
 import com.Flaground.backend.module.auth.controller.dto.response.JoinResponse;
 import com.Flaground.backend.module.auth.controller.dto.response.SignUpResponse;
 import com.Flaground.backend.module.auth.domain.AuthInformation;
@@ -32,25 +33,25 @@ public class AuthController {
 
     @Tag(name = "auth")
     @Operation(summary = "아이디 중복 체크")
-    @ApiResponse(responseCode = "200", description = "중복 체크 성공. False : 사용 가능, True : 사용 불가능")
+    @ApiResponse(responseCode = "200", description = "중복 체크 성공")
     @ResponseStatus(OK)
     @PostMapping("/check/id")
-    public ApplicationResponse<Boolean> checkId(@RequestBody @Valid CheckLoginIdRequest checkLoginIdRequest) {
-        boolean check = authService.validateDuplicateLoginId(checkLoginIdRequest.getLoginId());
-        return new ApplicationResponse<>(check);
+    public ApplicationResponse<DuplicationResponse> checkId(@RequestBody @Valid CheckLoginIdRequest checkLoginIdRequest) {
+        boolean isExist = authService.validateDuplicateLoginId(checkLoginIdRequest.getLoginId());
+        return new ApplicationResponse<>(DuplicationResponse.from(isExist));
     }
 
     @Tag(name = "auth")
     @Operation(summary = "이메일 중복 체크", description = "하나의 이메일에 하나의 계정만 생성 가능")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "중복 체크 성공. False : 사용 가능, True : 사용 불가능"),
+            @ApiResponse(responseCode = "200", description = "중복 체크 성공"),
             @ApiResponse(responseCode = "400", description = "이메일 형식이 아닙니다."),
     })
     @ResponseStatus(OK)
     @PostMapping("/check/email")
-    public ApplicationResponse<Boolean> checkEmail(@RequestBody @Valid CheckEmailRequest checkEmailRequest) {
-        boolean check = authService.validateDuplicateEmail(checkEmailRequest.getEmail());
-        return new ApplicationResponse<>(check);
+    public ApplicationResponse<DuplicationResponse> checkEmail(@RequestBody @Valid CheckEmailRequest checkEmailRequest) {
+        boolean isExist = authService.validateDuplicateEmail(checkEmailRequest.getEmail());
+        return new ApplicationResponse<>(DuplicationResponse.from(isExist));
     }
 
     @Tag(name = "auth")

--- a/src/main/java/com/Flaground/backend/module/auth/controller/dto/response/DuplicationResponse.java
+++ b/src/main/java/com/Flaground/backend/module/auth/controller/dto/response/DuplicationResponse.java
@@ -1,0 +1,14 @@
+package com.Flaground.backend.module.auth.controller.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class DuplicationResponse {
+    private boolean exist;
+
+    public static DuplicationResponse from(Boolean isExist) {
+        return new DuplicationResponse(isExist);
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/auth/domain/repository/implementation/AuthRepositoryImpl.java
+++ b/src/main/java/com/Flaground/backend/module/auth/domain/repository/implementation/AuthRepositoryImpl.java
@@ -27,7 +27,6 @@ public class AuthRepositoryImpl implements AuthRepositoryCustom {
                 .fetch();
     }
 
-    // todo: 최신 대상으로 쿼리 날리기
     @Override
     public List<SignUpRequestResponse> getSignUpRequests() {
         return queryFactory
@@ -38,6 +37,7 @@ public class AuthRepositoryImpl implements AuthRepositoryCustom {
                         authInformation.major))
                 .from(authInformation)
                 .where(authInformation.isAuthorizedCrew.eq(true))
+                .orderBy(authInformation.createdAt.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/auth/service/AuthService.java
+++ b/src/main/java/com/Flaground/backend/module/auth/service/AuthService.java
@@ -37,12 +37,12 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public Boolean validateDuplicateLoginId(String loginId) {
+    public boolean validateDuplicateLoginId(String loginId) {
         return memberService.isExistLoginId(loginId);
     }
 
     @Transactional(readOnly = true)
-    public Boolean validateDuplicateEmail(String email) {
+    public boolean validateDuplicateEmail(String email) {
         return memberService.isExistEmail(email);
     }
 

--- a/src/main/java/com/Flaground/backend/module/member/controller/MemberController.java
+++ b/src/main/java/com/Flaground/backend/module/member/controller/MemberController.java
@@ -5,10 +5,7 @@ import com.Flaground.backend.global.utility.SecurityUtils;
 import com.Flaground.backend.module.member.controller.dto.request.*;
 import com.Flaground.backend.module.member.controller.dto.response.*;
 import com.Flaground.backend.module.member.controller.mapper.MemberMapper;
-import com.Flaground.backend.module.member.domain.Avatar;
-import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.service.MemberService;
-import com.Flaground.backend.module.token.domain.Token;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -85,8 +82,8 @@ public class MemberController {
     @ResponseStatus(CREATED)
     @PostMapping("/find/id")
     public ApplicationResponse<RecoveryResponse> findId(@RequestBody @Valid FindIdRequest findIdRequest) {
-        Token token = memberService.findId(findIdRequest.getName(), findIdRequest.getEmail());
-        return new ApplicationResponse<>(memberMapper.toRecoveryResponse(token));
+        RecoveryResponse response = memberService.findId(findIdRequest.getName(), findIdRequest.getEmail());
+        return new ApplicationResponse<>(response);
     }
 
     @Tag(name = "member")
@@ -100,8 +97,8 @@ public class MemberController {
     @ResponseStatus(CREATED)
     @PostMapping("/find/password")
     public ApplicationResponse<RecoveryResponse> findPassword(@RequestBody @Valid FindPasswordRequest findPasswordRequest) {
-        Token token = memberService.findPassword(findPasswordRequest.getLoginId(), findPasswordRequest.getEmail());
-        return new ApplicationResponse<>(memberMapper.toRecoveryResponse(token));
+        RecoveryResponse response = memberService.findPassword(findPasswordRequest.getLoginId(), findPasswordRequest.getEmail());
+        return new ApplicationResponse<>(response);
     }
 
     @Tag(name = "member")
@@ -113,10 +110,10 @@ public class MemberController {
             @ApiResponse(responseCode = "409", description = "인증번호가 일치하지 않습니다.")
     })
     @ResponseStatus(OK)
-    @PostMapping("/certification") // todo : Controller가 member를 알고있음
+    @PostMapping("/certification")
     public ApplicationResponse<RecoveryResultResponse> verifyCertification(@RequestBody @Valid AuthenticationRequest authenticationRequest) {
-        Member member = memberService.verifyCertification(authenticationRequest.getEmail(), authenticationRequest.getCertification());
-        return new ApplicationResponse<>(memberMapper.toRecoveryResult(member));
+        RecoveryResultResponse response = memberService.validateCertification(authenticationRequest.getEmail(), authenticationRequest.getCertification());
+        return new ApplicationResponse<>(response);
     }
 
     @Tag(name = "member")
@@ -133,13 +130,13 @@ public class MemberController {
     }
 
     @Tag(name = "member")
-    @Operation(summary = "프로필 기본 이미지로 변경", description = "[토큰 필요]")
+    @Operation(summary = "프로필 기본 이미지로 변경", description = "[토큰 필요] 기본 이미지 URL을 내려준다.")
     @ApiResponses({})
     @ResponseStatus(OK)
     @PutMapping("/avatar/reset")
-    public ApplicationResponse resetProfileImage() {
-        memberService.resetProfileImage(SecurityUtils.getMemberId());
-        return new ApplicationResponse<>();
+    public ApplicationResponse<String> resetProfileImage() {
+        String defaultImageURL = memberService.resetProfileImage(SecurityUtils.getMemberId());
+        return new ApplicationResponse<>(defaultImageURL);
     }
 
     @Tag(name = "member")
@@ -177,10 +174,9 @@ public class MemberController {
             @ApiResponse(responseCode = "401", description = "토큰을 넣지 않으면 401 발생")
     })
     @ResponseStatus(OK)
-    @PutMapping("/avatar")
+    @PutMapping("/avatar") // todo : mapper 분리?
     public ApplicationResponse updateAvatar(@RequestBody @Valid UpdateAvatarRequest updateAvatarRequest) {
-        Avatar avatar = memberMapper.mapFrom(updateAvatarRequest);
-        memberService.updateAvatar(SecurityUtils.getMemberId(), avatar);
+        memberService.updateAvatar(SecurityUtils.getMemberId(), memberMapper.mapFrom(updateAvatarRequest));
         return new ApplicationResponse<>();
     }
 

--- a/src/main/java/com/Flaground/backend/module/member/controller/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/Flaground/backend/module/member/controller/dto/response/MyProfileResponse.java
@@ -9,10 +9,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyProfileResponse {
     @Schema(name = "닉네임", example = "john")
-    private String nickName;
+    private String nickname;
 
     @Schema(name = "자기소개", example = "안녕하세요?")
     private String bio;
@@ -37,9 +37,9 @@ public class MyProfileResponse {
 
     @Builder
     @QueryProjection
-    public MyProfileResponse(String nickName, String bio, String profileImg, String loginId,
+    public MyProfileResponse(String nickname, String bio, String profileImg, String loginId,
                              String name, String email, Major major, String studentId) {
-        this.nickName = nickName;
+        this.nickname = nickname;
         this.bio = bio;
         this.profileImg = profileImg;
         this.loginId = loginId;

--- a/src/main/java/com/Flaground/backend/module/member/controller/dto/response/RecoveryResponse.java
+++ b/src/main/java/com/Flaground/backend/module/member/controller/dto/response/RecoveryResponse.java
@@ -5,8 +5,10 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
+@Builder
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class RecoveryResponse {
     @Schema(name = "이메일", example = "gmlwh124@suwon.ac.kr")
     private String email;
@@ -14,9 +16,10 @@ public class RecoveryResponse {
     @Schema(name = "제한 시간")
     private LocalDateTime deadLine;
 
-    @Builder
-    public RecoveryResponse(String email, LocalDateTime deadLine) {
-        this.email = email;
-        this.deadLine = deadLine;
+    public static RecoveryResponse of(String email, LocalDateTime deadLine) {
+        return RecoveryResponse.builder()
+                .email(email)
+                .deadLine(deadLine)
+                .build();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/member/controller/dto/response/RecoveryResultResponse.java
+++ b/src/main/java/com/Flaground/backend/module/member/controller/dto/response/RecoveryResultResponse.java
@@ -1,13 +1,12 @@
 package com.Flaground.backend.module.member.controller.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Builder
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class RecoveryResultResponse {
     @Schema(name = "로그인 아이디")
     private String loginId;
@@ -15,9 +14,10 @@ public class RecoveryResultResponse {
     @Schema(name = "이메일")
     private String email;
 
-    @Builder
-    public RecoveryResultResponse(String loginId, String email) {
-        this.loginId = loginId;
-        this.email = email;
+    public static RecoveryResultResponse of(String loginId, String email) {
+        return RecoveryResultResponse.builder()
+                .loginId(loginId)
+                .email(email)
+                .build();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/member/controller/mapper/MemberMapper.java
+++ b/src/main/java/com/Flaground/backend/module/member/controller/mapper/MemberMapper.java
@@ -16,10 +16,4 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface MemberMapper {
     Avatar mapFrom(UpdateAvatarRequest updateAvatarRequest);
-
-    @Mapping(source = "key", target = "email")
-    @Mapping(source = "expiredAt", target = "deadLine")
-    RecoveryResponse toRecoveryResponse(Token findRequestToken);
-
-    RecoveryResultResponse toRecoveryResult(Member member);
 }

--- a/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
@@ -45,8 +45,9 @@ public class Avatar {
         this.profileImage = profileImage;
     }
 
-    public void resetProfileImage() {
+    public String resetProfileImage() {
         this.profileImage = DEFAULT_IMAGE;
+        return DEFAULT_IMAGE;
     }
 
     @Builder

--- a/src/main/java/com/Flaground/backend/module/member/domain/Member.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/Member.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
@@ -62,6 +63,30 @@ public class Member extends BaseEntity {
         }
     }
 
+    public void validateName(String name) {
+        if (!StringUtils.equals(this.name, name)) {
+            throw new CustomException(ErrorCode.EMAIL_NAME_NOT_MATCH);
+        }
+    }
+
+    public void validateLoginId(String loginId) {
+        if (!StringUtils.equals(this.loginId, loginId)) {
+            throw new CustomException(ErrorCode.EMAIL_ID_NOT_MATCH);
+        }
+    }
+
+    public void validatePassword(String password, PasswordEncoder passwordEncoder) {
+        if (!passwordEncoder.matches(password, this.password)) {
+            throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
+        }
+    }
+
+    public void validateSamePassword(String password, PasswordEncoder passwordEncoder) {
+        if (passwordEncoder.matches(password, this.password)) {
+            throw new CustomException(ErrorCode.PASSWORD_IS_SAME);
+        }
+    }
+
     public void updatePassword(String password, PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(password);
     }
@@ -70,8 +95,8 @@ public class Member extends BaseEntity {
         this.avatar.changeProfileImage(profileImage);
     }
 
-    public void resetProfileImage() {
-        this.avatar.resetProfileImage();
+    public String resetProfileImage() {
+        return avatar.resetProfileImage();
     }
 
     public void updateLoginTime() {

--- a/src/main/java/com/Flaground/backend/module/member/service/SleepingService.java
+++ b/src/main/java/com/Flaground/backend/module/member/service/SleepingService.java
@@ -6,10 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SleepingService {
     private final SleepingRepository sleepingRepository;
@@ -22,6 +20,7 @@ public class SleepingService {
         return sleepingRepository.existsByEmail(email);
     }
 
+    @Transactional
     public void reactivateMember(String loginId) {
         reactiveIfPresent(loginId);
         sleepingRepository.deleteByLoginId(loginId);

--- a/src/main/java/com/Flaground/backend/module/post/controller/PostController.java
+++ b/src/main/java/com/Flaground/backend/module/post/controller/PostController.java
@@ -187,7 +187,9 @@ public class PostController {
     }
 
     @Tag(name = "post")
-    @Operation(summary = "홈페이지 전용 Top 게시글 가져오기", description = "Condition(like or latest)에 따라 핫 게시글 또는 최신 게시글 5개를 가져온다.")
+    @Operation(summary = "홈페이지 전용 Top 게시글 가져오기", description = "Condition(like or latest)에 게시글을 5개 가져온다.<br>" +
+            "핫게시글 : 2주 이내에 게시글 중 좋아요가 높은 게시글<br>" +
+            "최신게시글 : 1주 이내에 게시글 중 최신 게시글")
     @ResponseStatus(OK)
     @GetMapping("/top/{condition}")
     public ApplicationResponse<List<PostResponse>> getTopFivePostByCondition(@PathVariable @EnumFormat(enumClass = TopPostCondition.class)

--- a/src/main/java/com/Flaground/backend/module/post/domain/enums/SearchPeriod.java
+++ b/src/main/java/com/Flaground/backend/module/post/domain/enums/SearchPeriod.java
@@ -14,12 +14,12 @@ import static com.Flaground.backend.module.post.domain.QPost.post;
 @RequiredArgsConstructor
 @JsonDeserialize(using = CustomEnumDeserializer.class)
 public enum SearchPeriod {
-    all("전체기간", null),
-    one_day("1일", post.createdAt.before(LocalDateTime.now().minusDays(1))),
-    one_week("1주일", post.createdAt.before(LocalDateTime.now().minusWeeks(1))),
-    one_month("1개월", post.createdAt.before(LocalDateTime.now().minusMonths(1))),
-    half_month("6개월", post.createdAt.before(LocalDateTime.now().minusMonths(6))),
-    one_year("1년", post.createdAt.before(LocalDateTime.now().minusYears(1)));
+    ALL("전체기간", null),
+    DAY("1일", post.createdAt.before(LocalDateTime.now().minusDays(1))),
+    WEEK("1주일", post.createdAt.before(LocalDateTime.now().minusWeeks(1))),
+    MONTH("1개월", post.createdAt.before(LocalDateTime.now().minusMonths(1))),
+    HALF_YEAR("6개월", post.createdAt.before(LocalDateTime.now().minusMonths(6))),
+    YEAR("1년", post.createdAt.before(LocalDateTime.now().minusYears(1)));
 
     private final String period;
     private final BooleanExpression expression;

--- a/src/main/java/com/Flaground/backend/module/token/domain/Token.java
+++ b/src/main/java/com/Flaground/backend/module/token/domain/Token.java
@@ -47,15 +47,16 @@ public abstract class Token {
         }
     }
 
-    public void validateExpireTime() {
-        if (this.expiredAt.isBefore(LocalDateTime.now())) {
-            throw new CustomException(ErrorCode.EXPIRED_AUTHENTICATION_TIME);
+    public void validateCertification(String certification) {
+        validateExpireTime();
+        if (!StringUtils.equals(certification, this.value)) {
+            throw new CustomException(ErrorCode.CERTIFICATION_NOT_MATCH);
         }
     }
 
-    public void verifyCertification(String certification) {
-        if (!StringUtils.equals(certification, this.value)) {
-            throw new CustomException(ErrorCode.CERTIFICATION_NOT_MATCH);
+    private void validateExpireTime() {
+        if (this.expiredAt.isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.EXPIRED_AUTHENTICATION_TIME);
         }
     }
 }

--- a/src/test/java/com/Flaground/backend/module/activity/ActivityRepositoryTest.java
+++ b/src/test/java/com/Flaground/backend/module/activity/ActivityRepositoryTest.java
@@ -260,13 +260,17 @@ public class ActivityRepositoryTest extends RepositoryTest {
         // given
         Member member = memberRepository.save(Member.builder().build());
         ActivityInfo info = ActivityInfo.builder().build();
-        activityRepository.save(Activity.builder().leader(member).info(info).build());
+
+        for (int i = 0; i < 5; i++) {
+            activityRepository.save(Activity.builder().leader(member).info(info).build());
+        }
+
 
         // when
         List<ActivityResponse> response = activityRepository.getRecruitActivities();
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.size()).isEqualTo(1);
+        assertThat(response.size()).isEqualTo(3);
     }
 }

--- a/src/test/java/com/Flaground/backend/module/member/MemberServiceSliceTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/MemberServiceSliceTest.java
@@ -3,6 +3,8 @@ package com.Flaground.backend.module.member;
 import com.Flaground.backend.common.MockServiceTest;
 import com.Flaground.backend.global.utility.RandomGenerator;
 import com.Flaground.backend.infra.aws.ses.service.MailService;
+import com.Flaground.backend.module.member.controller.dto.response.RecoveryResponse;
+import com.Flaground.backend.module.member.controller.dto.response.RecoveryResultResponse;
 import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.domain.repository.MemberRepository;
 import com.Flaground.backend.module.member.service.MemberService;
@@ -54,13 +56,13 @@ public class MemberServiceSliceTest extends MockServiceTest {
         doNothing().when(mailService).sendFindCertification(anyString(), anyString());
 
         // when
-        Token token = memberService.findId(name, email);
+        RecoveryResponse response = memberService.findId(name, email);
 
         // then
         then(recoveryTokenService).should(times(1)).issueToken(anyString(), anyString());
         then(mailService).should(times(1)).sendFindCertification(anyString(), anyString());
-        assertThat(token.getKey()).isEqualTo(email);
-        assertThat(token.getExpiredAt()).isEqualTo(findRequestToken.getExpiredAt());
+        assertThat(response.getEmail()).isEqualTo(email);
+        assertThat(response.getDeadLine()).isEqualTo(findRequestToken.getExpiredAt());
     }
 
     @Test
@@ -82,14 +84,14 @@ public class MemberServiceSliceTest extends MockServiceTest {
         doNothing().when(mailService).sendFindCertification(anyString(), anyString());
 
         // when
-        Token token = memberService.findPassword(loginId, email);
+        RecoveryResponse response = memberService.findPassword(loginId, email);
 
         // then
         then(memberRepository).should(times(1)).findByEmail(anyString());
         then(recoveryTokenService).should(times(1)).issueToken(anyString(), anyString());
         then(mailService).should(times(1)).sendFindCertification(anyString(), anyString());
-        assertThat(token.getKey()).isEqualTo(email);
-        assertThat(token.getExpiredAt()).isEqualTo(findRequestToken.getExpiredAt());
+        assertThat(response.getEmail()).isEqualTo(email);
+        assertThat(response.getDeadLine()).isEqualTo(findRequestToken.getExpiredAt());
     }
 
     @Test
@@ -106,12 +108,12 @@ public class MemberServiceSliceTest extends MockServiceTest {
         given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
 
         // when
-        Member returnMember = memberService.verifyCertification(email, certification);
+        RecoveryResultResponse response = memberService.validateCertification(email, certification);
 
         // then
         then(recoveryTokenService).should(times(1)).findToken(anyString());
         then(memberRepository).should(times(1)).findByEmail(anyString());
-        assertThat(returnMember.getLoginId()).isEqualTo(loginId);
-        assertThat(returnMember.getEmail()).isEqualTo(email);
+        assertThat(response.getLoginId()).isEqualTo(loginId);
+        assertThat(response.getEmail()).isEqualTo(email);
     }
 }

--- a/src/test/java/com/Flaground/backend/module/post/PostControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/post/PostControllerTest.java
@@ -404,7 +404,7 @@ public class PostControllerTest extends IntegrationTest {
                 .board(boardName)
                 .keyword(keyword)
                 .option(SearchOption.title)
-                .period(SearchPeriod.all)
+                .period(SearchPeriod.ALL)
                 .build();
 
         final String uri = BASE_URI + "/search";

--- a/src/test/java/com/Flaground/backend/module/post/PostRepositoryTest.java
+++ b/src/test/java/com/Flaground/backend/module/post/PostRepositoryTest.java
@@ -90,21 +90,16 @@ public class PostRepositoryTest extends RepositoryTest {
         void 핫게시글_가져오기_테스트() {
             // given
             final TopPostCondition condition = TopPostCondition.like;
-            final int hotPostLikeCount = 5;
 
-            Post notHotPost = postRepository.save(Post.builder().member(member).build());
-
-            for (int i = 1 ; i <= hotPostLikeCount; i++) {
-                if (i > 3) notHotPost.like();
-                post.like();
-            }
+            postRepository.save(Post.builder().member(member).build());
+            post.like();
 
             // when
             List<PostResponse> responses = postRepository.getTopFiveByCondition(condition);
 
             // then
             assertThat(responses.size()).isEqualTo(1);
-            assertThat(responses.get(0).getLikeCount()).isEqualTo(hotPostLikeCount);
+            assertThat(responses.get(0).getLikeCount()).isEqualTo(1);
         }
 
         @Test
@@ -127,7 +122,7 @@ public class PostRepositoryTest extends RepositoryTest {
     class 게시글_검색_테스트 {
         private Board board;
         private final String boardName = "자유게시판";
-        private final SearchPeriod period = SearchPeriod.all;
+        private final SearchPeriod period = SearchPeriod.ALL;
 
         @BeforeEach
         void setup() {


### PR DESCRIPTION
 - 회원가입 중복체크 Response 변경 (사유 : 가독성)
 - Member 유효성 검증로직 이동 (Service -> Domain)
 - 요구사항1 : 프로필사진 초기화 시 Default 이미지 리턴
 - 요구사항2 : 모집 중인 활동 3건만 리턴
 - 요구사항3 : 핫게시글은 조건 없이 높은 순서로 가져오기