### PR TITLE
[추가, 수정] 접근가능한 게시글 추가, JPA 활용 수정 (23.05.20 문희조)

### DIFF
--- a/src/main/java/com/Flaground/backend/module/activity/service/ActivityService.java
+++ b/src/main/java/com/Flaground/backend/module/activity/service/ActivityService.java
@@ -110,6 +110,7 @@ public class ActivityService {
         activity.finishActivity();
     }
 
+    // todo : 외래키 조약 오류
     public void delete(Long memberId, Long activityId) {
         Activity activity = validateLeaderAndReturnActivity(memberId, activityId);
         activityApplyService.deleteAllApplies(activityId);

--- a/src/main/java/com/Flaground/backend/module/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/repository/MemberRepository.java
@@ -3,10 +3,11 @@ package com.Flaground.backend.module.member.domain.repository;
 import com.Flaground.backend.module.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
-    Optional<Member> findById(Long memberId);
+    List<Member> findByLoginIdIn(List<String> loginIds);
 
     Optional<Member> findByLoginId(String loginId);
 

--- a/src/main/java/com/Flaground/backend/module/member/domain/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/repository/MemberRepositoryCustom.java
@@ -10,8 +10,6 @@ import java.util.List;
 public interface MemberRepositoryCustom {
     List<Member> getDeactivateMembers();
 
-    List<Member> getMembersByLoginIds(List<String> loginIdList);
-
     List<String> getDeactivableMemberEmails();
 
     MyProfileResponse getMyProfile(Long memberId);

--- a/src/main/java/com/Flaground/backend/module/member/domain/repository/implementation/MemberRepositoryImpl.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/repository/implementation/MemberRepositoryImpl.java
@@ -25,7 +25,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         return queryFactory
                 .selectFrom(member)
                 .where(member.updatedAt.before(limit),
-                        availableMember())
+                        isAvailableMember())
                 .fetch();
     }
 
@@ -37,15 +37,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(member.email)
                 .from(member)
                 .where(member.updatedAt.before(limit),
-                        availableMember())
-                .fetch();
-    }
-
-    @Override
-    public List<Member> getMembersByLoginIds(List<String> loginIdList) {
-        return queryFactory
-                .selectFrom(member)
-                .where(member.loginId.in(loginIdList))
+                        isAvailableMember())
                 .fetch();
     }
 
@@ -74,7 +66,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                         member.name,
                         member.updatedAt))
                 .from(member)
-                .where(availableMember())
+                .where(isAvailableMember())
                 .fetch();
     }
 
@@ -86,11 +78,11 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                         member.avatar.major))
                 .from(member)
                 .where(member.name.contains(name),
-                        availableMember())
+                        isAvailableMember())
                 .fetch();
     }
 
-    private BooleanExpression availableMember() {
-        return member.status.eq(MemberStatus.NORMAL).or(member.status.eq(MemberStatus.WATCHING));
+    private BooleanExpression isAvailableMember() {
+        return member.status.in(MemberStatus.NORMAL, MemberStatus.WATCHING);
     }
 }

--- a/src/main/java/com/Flaground/backend/module/member/service/MemberService.java
+++ b/src/main/java/com/Flaground/backend/module/member/service/MemberService.java
@@ -125,8 +125,8 @@ public class MemberService {
         return member.resetProfileImage();
     }
 
-    public List<Member> getMembersByLoginIds(List<String> loginIdList) {
-        return memberRepository.getMembersByLoginIds(loginIdList);
+    public List<Member> getMembersByLoginIds(List<String> loginIds) {
+        return memberRepository.findByLoginIdIn(loginIds);
     }
 
     public Member findByLoginId(String loginId) {

--- a/src/main/java/com/Flaground/backend/module/post/controller/PostController.java
+++ b/src/main/java/com/Flaground/backend/module/post/controller/PostController.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -167,8 +168,9 @@ public class PostController {
     })
     @ResponseStatus(OK)
     @GetMapping
-    public ApplicationResponse<Page<PostResponse>> getPostsByBoard(@RequestParam("board") @NotBlank String boardName, Pageable pageable) {
-        Page<PostResponse> response = postService.getPostsByBoard(boardName, pageable);
+    public ApplicationResponse<Page<PostResponse>> getPostsOfBoard(@RequestParam("board") @NotBlank String boardName,
+                                                                   PageRequest pageRequest) {
+        Page<PostResponse> response = postService.getPostsOfBoard(boardName, pageRequest);
         return new ApplicationResponse<>(response);
     }
 

--- a/src/main/java/com/Flaground/backend/module/post/domain/enums/PostStatus.java
+++ b/src/main/java/com/Flaground/backend/module/post/domain/enums/PostStatus.java
@@ -1,15 +1,8 @@
 package com.Flaground.backend.module.post.domain.enums;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
 public enum PostStatus {
-    NORMAL("정상"),
-    REPORTED("신고"),
-    BANNED("제재"),
-    DELETED("삭제");
-
-    private String status;
+    NORMAL,
+    REPORTED,
+    BANNED,
+    DELETED;
 }

--- a/src/main/java/com/Flaground/backend/module/post/domain/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/Flaground/backend/module/post/domain/repository/PostRepositoryCustom.java
@@ -24,9 +24,9 @@ public interface PostRepositoryCustom {
      */
     GetPostResponse getWithReplies(Long memberId, Long postId);
 
-    Page<PostResponse> getAllPostsByBoard(String boardName, Pageable pageable);
+    Page<PostResponse> getPostsOfBoard(String boardName, Pageable pageable);
 
-    List<PostResponse> getAllPostsByLoginId(String loginId);
+    List<PostResponse> getPostsByLoginId(String loginId);
 
     List<PostResponse> getTopFiveByCondition(TopPostCondition condition);
 

--- a/src/main/java/com/Flaground/backend/module/post/service/PostService.java
+++ b/src/main/java/com/Flaground/backend/module/post/service/PostService.java
@@ -119,16 +119,16 @@ public class PostService {
      * Version 2
      */
     @Transactional(readOnly = true)
-    public Page<PostResponse> getPostsByBoard(String boardName, Pageable pageable) {
+    public Page<PostResponse> getPostsOfBoard(String boardName, Pageable pageable) {
         boardService.isCorrectName(boardName);
-        return postRepository.getAllPostsByBoard(boardName, pageable);
+        return postRepository.getPostsOfBoard(boardName, pageable);
     }
 
     @Transactional(readOnly = true)
     public List<PostResponse> getMemberPagePosts(String loginId) {
         Member member = memberService.findByLoginId(loginId);
         member.isAvailable();
-        return postRepository.getAllPostsByLoginId(loginId);
+        return postRepository.getPostsByLoginId(loginId);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/Flaground/backend/module/member/MemberRepositoryTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/MemberRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.Flaground.backend.module.member;
+
+import com.Flaground.backend.common.RepositoryTest;
+import com.Flaground.backend.module.member.domain.Member;
+import com.Flaground.backend.module.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberRepositoryTest extends RepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 로그인_아이디들로_멤버_찾기_테스트() {
+        // given
+        final String loginId1 = "hejow1";
+        final String loginId2 = "hejow2";
+        final String loginId3 = "hejow3";
+
+        memberRepository.save(Member.builder().loginId(loginId1).build());
+        memberRepository.save(Member.builder().loginId(loginId2).build());
+        memberRepository.save(Member.builder().loginId(loginId3).build());
+
+        // when
+        List<Member> members = memberRepository.findByLoginIdIn(List.of(loginId1, loginId2, loginId3));
+
+        // then
+        assertThat(members.size()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
 - fetch 시 접근가능한 게시글인지 확인하도록 추가
 - 로그인 아이디로 엔티티 가져오기 수정 (queryDsl -> JPA)
 - 일부 메서드 이름 수정