### PR TITLE
[추가, 수정] 신고 처리, 로그인 실패 처리 추가 (23.05.27 문희조)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 /src/main/resources/application-s3.yml
 /src/main/resources/application-ses.yml
 /src/main/resources/application-db.yml
+**/.DS_Store
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/Flaground/backend/global/common/response/DuplicationResponse.java
+++ b/src/main/java/com/Flaground/backend/global/common/response/DuplicationResponse.java
@@ -1,6 +1,9 @@
 package com.Flaground.backend.global.common.response;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/Flaground/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/Flaground/backend/global/exception/ErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
     /** 400 - BAD_REQUEST */
-    REQUEST_VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    REQUEST_VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "잘못된 요청값입니다."),
+    LOCKED_ACCOUNT(HttpStatus.BAD_REQUEST, "잠겨있는 계정입니다. 비밀번호를 재설정하기 바랍니다."),
+    BANNED_ACCOUNT(HttpStatus.BAD_REQUEST, "일시정지된 계정입니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않는 토큰입니다."),
     EXPIRED_AUTHENTICATION_TIME(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다."),
     UNAVAILABLE_ACCOUNT(HttpStatus.BAD_REQUEST, "사용할 수 없는 계정입니다."),

--- a/src/main/java/com/Flaground/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/Flaground/backend/global/exception/ErrorResponse.java
@@ -1,5 +1,7 @@
 package com.Flaground.backend.global.exception;
 
+import com.Flaground.backend.global.exception.domain.CustomBadCredentialException;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,18 +10,27 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonPropertyOrder({"errorCode", "message"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
     private ErrorCode errorCode;
-
     private String message;
+    private Integer payload; // todo: 제네릭하게 수정하거나, 다른 방법 찾기
 
     public ErrorResponse(ErrorCode errorCode) {
         this.errorCode = errorCode;
         this.message = errorCode.getMessage();
+        this.payload = null;
     }
 
     public ErrorResponse(ErrorCode errorCode, String message) {
         this.errorCode = errorCode;
         this.message = message;
+        this.payload = null;
+    }
+
+    public ErrorResponse(CustomBadCredentialException e) {
+        this.errorCode = e.getErrorCode();
+        this.message = e.getMessage();
+        this.payload = e.getFailCount();
     }
 }

--- a/src/main/java/com/Flaground/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Flaground/backend/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,8 @@
 package com.Flaground.backend.global.exception;
 
+import com.Flaground.backend.global.exception.domain.CustomBadCredentialException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -27,13 +27,13 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * 로그인 실패로 던져지는 예외 핸들러 (비활성, 잠금 예외는 제외)
+     * 로그인 실패(비밀번호 불일치)를 처리하는 예외 핸들러
      */
-    @ExceptionHandler(BadCredentialsException.class)
+    @ExceptionHandler(CustomBadCredentialException.class)
     @ResponseStatus(BAD_REQUEST)
-    public ErrorResponse handleBadCredentialsException(BadCredentialsException e) {
-        log.error("LoginFailed (BadCredentials) : {}", e.getMessage());
-        return new ErrorResponse(ErrorCode.PASSWORD_NOT_MATCH);
+    public ErrorResponse handleBadCredentialsException(CustomBadCredentialException e) {
+        log.error("LoginFailed (BadCredential) : {}", e.getMessage());
+        return new ErrorResponse(e);
     }
 
     /**

--- a/src/main/java/com/Flaground/backend/global/exception/domain/CustomBadCredentialException.java
+++ b/src/main/java/com/Flaground/backend/global/exception/domain/CustomBadCredentialException.java
@@ -1,0 +1,14 @@
+package com.Flaground.backend.global.exception.domain;
+
+import com.Flaground.backend.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomBadCredentialException extends LoginFailException {
+    private final int failCount;
+
+    public CustomBadCredentialException(ErrorCode errorCode, int failCount) {
+        super(errorCode);
+        this.failCount = failCount;
+    }
+}

--- a/src/main/java/com/Flaground/backend/global/exception/domain/LoginFailException.java
+++ b/src/main/java/com/Flaground/backend/global/exception/domain/LoginFailException.java
@@ -1,0 +1,13 @@
+package com.Flaground.backend.global.exception.domain;
+
+import com.Flaground.backend.global.exception.CustomException;
+import com.Flaground.backend.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class LoginFailException extends CustomException {
+
+    public LoginFailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/Flaground/backend/infra/aws/s3/entity/File.java
+++ b/src/main/java/com/Flaground/backend/infra/aws/s3/entity/File.java
@@ -1,8 +1,8 @@
 package com.Flaground.backend.infra.aws.s3.entity;
 
-import com.Flaground.backend.module.post.domain.Post;
 import com.Flaground.backend.global.common.BaseEntity;
 import com.Flaground.backend.infra.aws.s3.entity.enums.FileStatus;
+import com.Flaground.backend.module.post.domain.Post;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/Flaground/backend/infra/aws/s3/service/AwsS3Service.java
+++ b/src/main/java/com/Flaground/backend/infra/aws/s3/service/AwsS3Service.java
@@ -1,79 +1,8 @@
 package com.Flaground.backend.infra.aws.s3.service;
 
-import com.Flaground.backend.global.exception.CustomException;
-import com.Flaground.backend.global.exception.ErrorCode;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.UUID;
-
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class AwsS3Service {
-    private final AmazonS3Client amazonS3Client;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    public String upload(MultipartFile file, String directory) {
-        String fileName = createFileName(file, directory);
-        String fileUrl = putS3(file, fileName);
-        log.info("[File Uploaded] directory : {}, URL : {}", directory , fileUrl);
-        return fileUrl;
-    }
-
-//    public List<String> upload(List<MultipartFile> fileList) {
-//        List<String> uploadedFileUriList = new ArrayList<>();
-//
-//        for(MultipartFile eachFile : fileList) {
-//            String fileName = createFileName(eachFile);
-//            String uploadedFileUri = putS3(eachFile, fileName);
-//            uploadedFileUriList.add(uploadedFileUri);
-//        }
-//
-//        return uploadedFileUriList;
-//    }
-
-    public void delete(String imageName, String directory) {
-        String fileName = directory + "/" + imageName;
-        amazonS3Client.deleteObject(bucket, fileName);
-        log.info("[File Deleted] Directory : {}, FileName : {}", directory, fileName);
-    }
-
-    private String createFileName(MultipartFile file, String directory) {
-        String[] split = Objects.requireNonNull(Objects.requireNonNull(file.getContentType()).split("/"));
-        String extension = split[split.length - 1];
-        return directory + "/" + UUID.randomUUID() + "." + extension;
-    }
-
-    private String putS3(MultipartFile file, String fileName) {
-        amazonS3Client.putObject(createPutObjectRequest(file, fileName));
-        return amazonS3Client.getUrl(bucket, fileName).toString();
-    }
-
-    private PutObjectRequest createPutObjectRequest(MultipartFile file, String fileName) {
-        try {
-            return new PutObjectRequest(bucket, fileName, file.getInputStream(), createObjectMetaData(file))
-                    .withCannedAcl(CannedAccessControlList.PublicRead);
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.FILE_CONVERT_FAIL);
-        }
-    }
-
-    private ObjectMetadata createObjectMetaData(MultipartFile file) {
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentType(file.getContentType());
-        objectMetadata.setContentLength(file.getSize());
-        return objectMetadata;
-    }
+public interface AwsS3Service {
+    String upload(MultipartFile file, String directory);
+    void delete(String imageName, String directory);
 }

--- a/src/main/java/com/Flaground/backend/infra/aws/s3/service/AwsS3ServiceImpl.java
+++ b/src/main/java/com/Flaground/backend/infra/aws/s3/service/AwsS3ServiceImpl.java
@@ -1,0 +1,81 @@
+package com.Flaground.backend.infra.aws.s3.service;
+
+import com.Flaground.backend.global.exception.CustomException;
+import com.Flaground.backend.global.exception.ErrorCode;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsS3ServiceImpl implements AwsS3Service {
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String upload(MultipartFile file, String directory) {
+        String fileName = createFileName(file, directory);
+        String fileUrl = putS3(file, fileName);
+        log.info("[File Uploaded] directory : {}, URL : {}", directory , fileUrl);
+        return fileUrl;
+    }
+
+//    public List<String> upload(List<MultipartFile> fileList) {
+//        List<String> uploadedFileUriList = new ArrayList<>();
+//
+//        for(MultipartFile eachFile : fileList) {
+//            String fileName = createFileName(eachFile);
+//            String uploadedFileUri = putS3(eachFile, fileName);
+//            uploadedFileUriList.add(uploadedFileUri);
+//        }
+//
+//        return uploadedFileUriList;
+//    }
+
+    @Override
+    public void delete(String imageName, String directory) {
+        String fileName = directory + "/" + imageName;
+        amazonS3Client.deleteObject(bucket, fileName);
+        log.info("[File Deleted] Directory : {}, FileName : {}", directory, fileName);
+    }
+
+    private String createFileName(MultipartFile file, String directory) {
+        String[] split = Objects.requireNonNull(Objects.requireNonNull(file.getContentType()).split("/"));
+        String extension = split[split.length - 1];
+        return directory + "/" + UUID.randomUUID() + "." + extension;
+    }
+
+    private String putS3(MultipartFile file, String fileName) {
+        amazonS3Client.putObject(createPutObjectRequest(file, fileName));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private PutObjectRequest createPutObjectRequest(MultipartFile file, String fileName) {
+        try {
+            return new PutObjectRequest(bucket, fileName, file.getInputStream(), createObjectMetaData(file))
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_CONVERT_FAIL);
+        }
+    }
+
+    private ObjectMetadata createObjectMetaData(MultipartFile file) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getSize());
+        return objectMetadata;
+    }
+}

--- a/src/main/java/com/Flaground/backend/infra/aws/ses/service/AwsSESService.java
+++ b/src/main/java/com/Flaground/backend/infra/aws/ses/service/AwsSESService.java
@@ -1,0 +1,7 @@
+package com.Flaground.backend.infra.aws.ses.service;
+
+public interface AwsSESService {
+    void sendCertification(String email, String result);
+    void sendFindCertification(String email, String result);
+    void sendChangeSleep(String email);
+}

--- a/src/main/java/com/Flaground/backend/infra/aws/ses/service/AwsSESServiceImpl.java
+++ b/src/main/java/com/Flaground/backend/infra/aws/ses/service/AwsSESServiceImpl.java
@@ -4,15 +4,16 @@ import com.Flaground.backend.infra.aws.ses.MailType;
 import com.Flaground.backend.infra.aws.ses.dto.MailRequest;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Log4j2
+@Slf4j
 @Service
 @RequiredArgsConstructor
-public class MailService {
+public class AwsSESServiceImpl implements AwsSESService {
     private final AmazonSimpleEmailService emailService;
 
+    @Override
     public void sendCertification(String email, String result) {
         MailRequest mailRequest = MailRequest.builder()
                 .to(email)
@@ -24,6 +25,7 @@ public class MailService {
         log.info("Email sent : " + email);
     }
 
+    @Override
     public void sendFindCertification(String email, String result) {
         MailRequest mailRequest = MailRequest.builder()
                 .to(email)
@@ -35,6 +37,7 @@ public class MailService {
         log.info("Email sent : " + email);
     }
 
+    @Override
     public void sendChangeSleep(String email) {
         MailRequest mailRequest = MailRequest.builder()
                 .to(email)

--- a/src/main/java/com/Flaground/backend/module/activity/controller/ActivityController.java
+++ b/src/main/java/com/Flaground/backend/module/activity/controller/ActivityController.java
@@ -1,22 +1,17 @@
 package com.Flaground.backend.module.activity.controller;
 
+import com.Flaground.backend.global.common.response.ApplicationResponse;
 import com.Flaground.backend.global.common.response.DuplicationResponse;
 import com.Flaground.backend.global.common.response.SearchResponse;
-import com.Flaground.backend.module.activity.controller.dto.response.ActivityApplyResponse;
+import com.Flaground.backend.global.utility.SecurityUtils;
+import com.Flaground.backend.global.utility.UriCreator;
 import com.Flaground.backend.module.activity.controller.dto.request.CloseRecruitRequest;
 import com.Flaground.backend.module.activity.controller.dto.request.CreateActivityRequest;
 import com.Flaground.backend.module.activity.controller.dto.request.UpdateActivityRequest;
-import com.Flaground.backend.module.activity.controller.dto.response.ActivityDetailResponse;
-import com.Flaground.backend.module.activity.controller.dto.response.ActivityResponse;
-import com.Flaground.backend.module.activity.controller.dto.response.GetAllActivitiesResponse;
-import com.Flaground.backend.module.activity.domain.Activity;
+import com.Flaground.backend.module.activity.controller.dto.response.*;
 import com.Flaground.backend.module.activity.controller.mapper.ActivityMapper;
-import com.Flaground.backend.module.activity.controller.dto.response.ParticipantResponse;
-import com.Flaground.backend.module.activity.controller.dto.response.ParticipateResponse;
+import com.Flaground.backend.module.activity.domain.Activity;
 import com.Flaground.backend.module.activity.service.ActivityService;
-import com.Flaground.backend.global.common.response.ApplicationResponse;
-import com.Flaground.backend.global.utility.SecurityUtils;
-import com.Flaground.backend.global.utility.UriCreator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;

--- a/src/main/java/com/Flaground/backend/module/activity/controller/mapper/ActivityMapper.java
+++ b/src/main/java/com/Flaground/backend/module/activity/controller/mapper/ActivityMapper.java
@@ -1,12 +1,15 @@
 package com.Flaground.backend.module.activity.controller.mapper;
 
-import com.Flaground.backend.module.activity.controller.dto.request.CreateActivityRequest;
 import com.Flaground.backend.module.activity.controller.dto.request.ActivityInfoRequest;
+import com.Flaground.backend.module.activity.controller.dto.request.CreateActivityRequest;
 import com.Flaground.backend.module.activity.controller.dto.request.UpdateActivityRequest;
 import com.Flaground.backend.module.activity.controller.dto.response.ActivityDetailResponse;
 import com.Flaground.backend.module.activity.domain.Activity;
 import com.Flaground.backend.module.activity.domain.ActivityInfo;
-import org.mapstruct.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.ReportingPolicy;
 
 @Mapper(
         componentModel = "spring",

--- a/src/main/java/com/Flaground/backend/module/activity/domain/Activity.java
+++ b/src/main/java/com/Flaground/backend/module/activity/domain/Activity.java
@@ -1,11 +1,11 @@
 package com.Flaground.backend.module.activity.domain;
 
-import com.Flaground.backend.module.activity.domain.enums.ActivityStatus;
-import com.Flaground.backend.module.activity.domain.enums.ActivityType;
-import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.global.common.BaseEntity;
 import com.Flaground.backend.global.exception.CustomException;
 import com.Flaground.backend.global.exception.ErrorCode;
+import com.Flaground.backend.module.activity.domain.enums.ActivityStatus;
+import com.Flaground.backend.module.activity.domain.enums.ActivityType;
+import com.Flaground.backend.module.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/Flaground/backend/module/activity/domain/MemberActivity.java
+++ b/src/main/java/com/Flaground/backend/module/activity/domain/MemberActivity.java
@@ -2,7 +2,10 @@ package com.Flaground.backend.module.activity.domain;
 
 import com.Flaground.backend.global.common.BaseEntity;
 import com.Flaground.backend.module.member.domain.Member;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/Flaground/backend/module/activity/service/ActivityApplyService.java
+++ b/src/main/java/com/Flaground/backend/module/activity/service/ActivityApplyService.java
@@ -3,7 +3,6 @@ package com.Flaground.backend.module.activity.service;
 import com.Flaground.backend.module.activity.controller.dto.response.ActivityApplyResponse;
 import com.Flaground.backend.module.activity.domain.ActivityApply;
 import com.Flaground.backend.module.activity.domain.repository.ActivityApplyRepository;
-import com.Flaground.backend.module.activity.domain.Activity;
 import com.Flaground.backend.module.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/Flaground/backend/module/activity/service/ActivityService.java
+++ b/src/main/java/com/Flaground/backend/module/activity/service/ActivityService.java
@@ -1,18 +1,13 @@
 package com.Flaground.backend.module.activity.service;
 
 import com.Flaground.backend.global.common.response.SearchResponse;
-import com.Flaground.backend.module.activity.controller.dto.response.ActivityApplyResponse;
-import com.Flaground.backend.module.activity.domain.ActivityApply;
-import com.Flaground.backend.module.activity.controller.dto.response.ActivityResponse;
-import com.Flaground.backend.module.activity.controller.dto.response.GetAllActivitiesResponse;
+import com.Flaground.backend.global.exception.CustomException;
+import com.Flaground.backend.global.exception.ErrorCode;
+import com.Flaground.backend.module.activity.controller.dto.response.*;
 import com.Flaground.backend.module.activity.domain.Activity;
-import com.Flaground.backend.module.activity.controller.dto.response.ParticipantResponse;
-import com.Flaground.backend.module.activity.controller.dto.response.ParticipateResponse;
 import com.Flaground.backend.module.activity.domain.repository.ActivityRepository;
 import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.service.MemberService;
-import com.Flaground.backend.global.exception.CustomException;
-import com.Flaground.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +37,7 @@ public class ActivityService {
     @Transactional(readOnly = true)
     public List<ParticipateResponse> getMemberPageActivities(String loginId) {
         Member member = memberService.findByLoginId(loginId);
-        member.isAvailable();
+        member.isWithdraw();
         return memberActivityService.getAllActivitiesOfMember(loginId);
     }
 

--- a/src/main/java/com/Flaground/backend/module/activity/service/MemberActivityService.java
+++ b/src/main/java/com/Flaground/backend/module/activity/service/MemberActivityService.java
@@ -1,8 +1,8 @@
 package com.Flaground.backend.module.activity.service;
 
-import com.Flaground.backend.module.activity.domain.Activity;
 import com.Flaground.backend.module.activity.controller.dto.response.ParticipantResponse;
 import com.Flaground.backend.module.activity.controller.dto.response.ParticipateResponse;
+import com.Flaground.backend.module.activity.domain.Activity;
 import com.Flaground.backend.module.activity.domain.MemberActivity;
 import com.Flaground.backend.module.activity.domain.repository.MemberActivityRepository;
 import com.Flaground.backend.module.member.domain.Member;

--- a/src/main/java/com/Flaground/backend/module/admin/controller/AdminController.java
+++ b/src/main/java/com/Flaground/backend/module/admin/controller/AdminController.java
@@ -45,8 +45,8 @@ public class AdminController {
     @Tag(name = "admin")
     @ResponseStatus(OK)
     @GetMapping("/reports")
-    public ApplicationResponse<List<ReportResponse>> getReports() {
-        List<ReportResponse> responses = adminService.getReports();
+    public ApplicationResponse<ReportResponse> getReports() {
+        ReportResponse responses = adminService.getReports();
         return new ApplicationResponse<>(responses);
     }
 

--- a/src/main/java/com/Flaground/backend/module/admin/service/AdminService.java
+++ b/src/main/java/com/Flaground/backend/module/admin/service/AdminService.java
@@ -6,8 +6,10 @@ import com.Flaground.backend.module.auth.service.AuthService;
 import com.Flaground.backend.module.board.domain.Board;
 import com.Flaground.backend.module.board.service.BoardService;
 import com.Flaground.backend.module.member.controller.dto.response.LoginLogResponse;
+import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.service.MemberService;
 import com.Flaground.backend.module.report.controller.dto.response.ReportResponse;
+import com.Flaground.backend.module.report.domain.Report;
 import com.Flaground.backend.module.report.service.ReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -59,5 +61,12 @@ public class AdminService {
 
     public void deleteBoard(String boardName) {
         boardService.delete(boardName);
+    }
+
+    public void handleReport(Long reportId) {
+        Report report = reportService.findById(reportId);
+        Member member = memberService.findById(report.getReported());
+        member.applyPenalty(report.getPenalty());
+        reportService.delete(reportId);
     }
 }

--- a/src/main/java/com/Flaground/backend/module/admin/service/AdminService.java
+++ b/src/main/java/com/Flaground/backend/module/admin/service/AdminService.java
@@ -35,7 +35,7 @@ public class AdminService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReportResponse> getReports() {
+    public ReportResponse getReports() {
         return reportService.getReports();
     }
 

--- a/src/main/java/com/Flaground/backend/module/auth/controller/dto/request/LoginRequest.java
+++ b/src/main/java/com/Flaground/backend/module/auth/controller/dto/request/LoginRequest.java
@@ -1,6 +1,5 @@
 package com.Flaground.backend.module.auth.controller.dto.request;
 
-import com.Flaground.backend.global.annotation.PasswordFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,7 +16,7 @@ public class LoginRequest {
     private String loginId;
 
     @Schema(description = "비밀번호", example = "qwer1234!")
-    @PasswordFormat
+    @NotBlank
     private String password;
 
     @Builder

--- a/src/main/java/com/Flaground/backend/module/auth/controller/mapper/AuthMapper.java
+++ b/src/main/java/com/Flaground/backend/module/auth/controller/mapper/AuthMapper.java
@@ -3,7 +3,9 @@ package com.Flaground.backend.module.auth.controller.mapper;
 import com.Flaground.backend.global.utility.RandomGenerator;
 import com.Flaground.backend.module.auth.controller.dto.request.JoinRequest;
 import com.Flaground.backend.module.auth.domain.AuthInformation;
-import org.mapstruct.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
 @Mapper(
         componentModel = "spring",

--- a/src/main/java/com/Flaground/backend/module/auth/service/AuthService.java
+++ b/src/main/java/com/Flaground/backend/module/auth/service/AuthService.java
@@ -4,7 +4,7 @@ import com.Flaground.backend.global.exception.CustomException;
 import com.Flaground.backend.global.exception.ErrorCode;
 import com.Flaground.backend.global.exception.domain.CustomBadCredentialException;
 import com.Flaground.backend.global.jwt.JwtUtilizer;
-import com.Flaground.backend.infra.aws.ses.service.MailService;
+import com.Flaground.backend.infra.aws.ses.service.AwsSESServiceImpl;
 import com.Flaground.backend.module.auth.controller.dto.response.SignUpRequestResponse;
 import com.Flaground.backend.module.auth.domain.AuthInformation;
 import com.Flaground.backend.module.auth.domain.repository.AuthRepository;
@@ -30,7 +30,7 @@ public class AuthService {
     private final AuthRepository authRepository;
     private final MemberService memberService;
     private final RefreshTokenService refreshTokenService;
-    private final MailService mailService;
+    private final AwsSESServiceImpl mailService;
     private final JwtUtilizer jwtUtilizer;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
@@ -81,12 +81,6 @@ public class AuthService {
         return tokenResponse;
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public int loginFailed(String loginId) {
-        Member member = memberService.findByLoginId(loginId);
-        return member.loginFail();
-    }
-
     @Transactional
     public TokenResponse reissueToken(String accessToken, String refreshToken) {
         return refreshTokenService.reissueToken(accessToken, refreshToken);
@@ -119,7 +113,7 @@ public class AuthService {
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginId, password);
             return authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         } catch (BadCredentialsException e) {
-            int failCount = loginFailed(loginId);
+            int failCount = memberService. loginFailed(loginId);
             throw new CustomBadCredentialException(ErrorCode.PASSWORD_NOT_MATCH, failCount);
         }
     }

--- a/src/main/java/com/Flaground/backend/module/board/domain/Board.java
+++ b/src/main/java/com/Flaground/backend/module/board/domain/Board.java
@@ -1,5 +1,6 @@
 package com.Flaground.backend.module.board.domain;
 
+import com.Flaground.backend.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Board {
+public class Board extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/Flaground/backend/module/member/controller/MemberController.java
+++ b/src/main/java/com/Flaground/backend/module/member/controller/MemberController.java
@@ -67,7 +67,7 @@ public class MemberController {
     @ResponseStatus(OK)
     @GetMapping("/search")
     public ApplicationResponse<SearchResponse> searchMemberByName(@RequestParam @NotBlank String name) {
-        SearchResponse response = memberService.searchMember(name);
+        SearchResponse<SearchMemberResponse> response = memberService.searchMember(name);
         return new ApplicationResponse<>(response);
     }
 
@@ -131,7 +131,7 @@ public class MemberController {
 
     @Tag(name = "member")
     @Operation(summary = "프로필 기본 이미지로 변경", description = "[토큰 필요] 기본 이미지 URL을 내려준다.")
-    @ApiResponses({})
+    @ApiResponse(responseCode = "200", description = "프로필 사진 초기화완료")
     @ResponseStatus(OK)
     @PutMapping("/avatar/reset")
     public ApplicationResponse<String> resetProfileImage() {

--- a/src/main/java/com/Flaground/backend/module/member/controller/mapper/MemberMapper.java
+++ b/src/main/java/com/Flaground/backend/module/member/controller/mapper/MemberMapper.java
@@ -1,13 +1,8 @@
 package com.Flaground.backend.module.member.controller.mapper;
 
 import com.Flaground.backend.module.member.controller.dto.request.UpdateAvatarRequest;
-import com.Flaground.backend.module.member.controller.dto.response.RecoveryResponse;
-import com.Flaground.backend.module.member.controller.dto.response.RecoveryResultResponse;
 import com.Flaground.backend.module.member.domain.Avatar;
-import com.Flaground.backend.module.member.domain.Member;
-import com.Flaground.backend.module.token.domain.Token;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(

--- a/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
@@ -16,6 +16,7 @@ import javax.persistence.Enumerated;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class Avatar {
+    // todo: 보안을 위해 앞에 엔드포인트 제거하도록 수정
     private static final String DEFAULT_IMAGE = "https://flaground-s3.s3.ap-northeast-2.amazonaws.com/avatar/default_image.jpg";
     private static final String BLANK = " ";
 

--- a/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
@@ -34,6 +34,24 @@ public class Avatar {
     @Column(name = "profile_img")
     private String profileImage;
 
+    @Builder
+    public Avatar(String nickname, String studentId, Major major, String bio) {
+        this.nickname = nickname;
+        this.studentId = studentId;
+        this.major = major;
+        this.bio = bio;
+        this.profileImage = DEFAULT_IMAGE;
+    }
+
+    public static Avatar of(String nickName, String studentId, Major major) {
+        return Avatar.builder()
+                .nickname(nickName)
+                .studentId(studentId)
+                .major(major)
+                .bio(" ")
+                .build();
+    }
+
     public void updateAvatar(Avatar avatar) {
         this.nickname = avatar.getNickname();
         this.studentId = avatar.getStudentId();
@@ -50,27 +68,9 @@ public class Avatar {
         return DEFAULT_IMAGE;
     }
 
-    @Builder
-    public Avatar(String nickname, String studentId, Major major, String bio) {
-        this.nickname = nickname;
-        this.studentId = studentId;
-        this.major = major;
-        this.bio = bio;
-        this.profileImage = DEFAULT_IMAGE;
-    }
-
     public void deactivate() {
         this.studentId = null;
         this.major = null;
         this.profileImage = DEFAULT_IMAGE;
-    }
-
-    public static Avatar of(String nickName, String studentId, Major major) {
-        return Avatar.builder()
-                .nickname(nickName)
-                .studentId(studentId)
-                .major(major)
-                .bio(" ")
-                .build();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/Avatar.java
@@ -17,6 +17,7 @@ import javax.persistence.Enumerated;
 @Embeddable
 public class Avatar {
     private static final String DEFAULT_IMAGE = "https://flaground-s3.s3.ap-northeast-2.amazonaws.com/avatar/default_image.jpg";
+    private static final String BLANK = " ";
 
     @Column(length = 20)
     private String nickname;
@@ -48,7 +49,7 @@ public class Avatar {
                 .nickname(nickName)
                 .studentId(studentId)
                 .major(major)
-                .bio(" ")
+                .bio(BLANK)
                 .build();
     }
 
@@ -68,7 +69,7 @@ public class Avatar {
         return DEFAULT_IMAGE;
     }
 
-    public void deactivate() {
+    public void cleanUp() {
         this.studentId = null;
         this.major = null;
         this.profileImage = DEFAULT_IMAGE;

--- a/src/main/java/com/Flaground/backend/module/member/domain/IssueRecord.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/IssueRecord.java
@@ -1,0 +1,40 @@
+package com.Flaground.backend.module.member.domain;
+
+import lombok.Getter;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Getter
+@Embeddable
+public class IssueRecord {
+    private static final int START_VALUE = 0;
+
+    @Column(name = "login_failed")
+    private int loginFailCount;
+
+    @Column(name = "reported_count")
+    private int reportedCount;
+
+    @Column(name = "penalty_point")
+    private int penaltyPoint;
+
+    public IssueRecord() {
+        this.loginFailCount = START_VALUE;
+        this.reportedCount = START_VALUE;
+        this.penaltyPoint = START_VALUE;
+    }
+
+    public int loginFail() {
+        return ++this.loginFailCount;
+    }
+
+    public void resetLoginFailCount() {
+        this.loginFailCount = START_VALUE;
+    }
+
+    public void applyPenalty(int penaltyPoint) {
+        this.penaltyPoint += penaltyPoint;
+        this.reportedCount++;
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/member/domain/IssueRecord.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/IssueRecord.java
@@ -8,6 +8,7 @@ import javax.persistence.Embeddable;
 @Getter
 @Embeddable
 public class IssueRecord {
+    private static final int LOCK_VALUE = 5;
     private static final int START_VALUE = 0;
 
     @Column(name = "login_failed")
@@ -25,8 +26,12 @@ public class IssueRecord {
         this.penaltyPoint = START_VALUE;
     }
 
-    public int loginFail() {
-        return ++this.loginFailCount;
+    public boolean isMaxLoginFailCount() {
+        return this.loginFailCount == LOCK_VALUE;
+    }
+
+    public void increaseFailCount() {
+        this.loginFailCount++;
     }
 
     public void resetLoginFailCount() {

--- a/src/main/java/com/Flaground/backend/module/member/domain/Member.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/Member.java
@@ -104,7 +104,7 @@ public class Member extends BaseEntity {
     }
 
     public void changeProfileImage(String profileImage) {
-        this.avatar.changeProfileImage(profileImage);
+        avatar.changeProfileImage(profileImage);
     }
 
     public String resetProfileImage() {
@@ -113,6 +113,10 @@ public class Member extends BaseEntity {
 
     public void updateLoginTime() {
         super.updateModifiedDate();
+    }
+
+    public int getFailCount() {
+        return issueRecord.getLoginFailCount();
     }
 
     public void reactivate(String loginId, String password, String email, String name) {
@@ -132,20 +136,15 @@ public class Member extends BaseEntity {
         this.avatar.cleanUp();
     }
 
-    public int loginFail() {
-        return issueRecord.loginFail();
+    public void loginFail() {
+        issueRecord.increaseFailCount();
+        if (issueRecord.isMaxLoginFailCount()) {
+            lock();
+        }
     }
 
     public void applyPenalty(int penaltyPoint) {
         issueRecord.applyPenalty(penaltyPoint);
-    }
-
-    public void lock() {
-        this.status = MemberStatus.LOCKED;
-    }
-
-    public void ban() {
-        this.status = MemberStatus.BANNED;
     }
 
     public void withdraw() {
@@ -169,5 +168,13 @@ public class Member extends BaseEntity {
         if (this.status == MemberStatus.LOCKED) {
             throw new LoginFailException(ErrorCode.LOCKED_ACCOUNT);
         }
+    }
+
+    private void lock() {
+        this.status = MemberStatus.LOCKED;
+    }
+
+    private void ban() {
+        this.status = MemberStatus.BANNED;
     }
 }

--- a/src/main/java/com/Flaground/backend/module/member/domain/enums/MemberStatus.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/enums/MemberStatus.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum MemberStatus {
     NORMAL("일반"),
     BANNED("정지"),
-    WATCHING("감시"),
+    LOCKED("잠금"),
     WITHDRAW("회원 탈퇴"),
     SLEEPING("휴면계정");
 

--- a/src/main/java/com/Flaground/backend/module/member/domain/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/repository/MemberRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.Flaground.backend.module.member.domain.repository;
 import com.Flaground.backend.global.common.response.SearchResponse;
 import com.Flaground.backend.module.member.controller.dto.response.LoginLogResponse;
 import com.Flaground.backend.module.member.controller.dto.response.MyProfileResponse;
+import com.Flaground.backend.module.member.controller.dto.response.SearchMemberResponse;
 import com.Flaground.backend.module.member.domain.Member;
 
 import java.util.List;
@@ -16,5 +17,5 @@ public interface MemberRepositoryCustom {
 
     List<LoginLogResponse> getLoginLogs();
 
-    SearchResponse searchMemberByName(String name);
+    SearchResponse<SearchMemberResponse> searchMemberByName(String name);
 }

--- a/src/main/java/com/Flaground/backend/module/member/domain/repository/SleepingRepositoryCustom.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/repository/SleepingRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.Flaground.backend.module.member.domain.repository;
 
 import com.Flaground.backend.module.member.domain.Sleeping;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 

--- a/src/main/java/com/Flaground/backend/module/member/domain/repository/implementation/MemberRepositoryImpl.java
+++ b/src/main/java/com/Flaground/backend/module/member/domain/repository/implementation/MemberRepositoryImpl.java
@@ -72,7 +72,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     }
 
     @Override
-    public SearchResponse searchMemberByName(String name) {
+    public SearchResponse<SearchMemberResponse> searchMemberByName(String name) {
         List<SearchMemberResponse> responses = queryFactory
                 .select(new QSearchMemberResponse(
                         member.loginId,
@@ -87,6 +87,6 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     }
 
     private BooleanExpression isAvailableMember() {
-        return member.status.in(MemberStatus.NORMAL, MemberStatus.WATCHING);
+        return member.status.eq(MemberStatus.NORMAL);
     }
 }

--- a/src/main/java/com/Flaground/backend/module/member/service/MemberScheduleService.java
+++ b/src/main/java/com/Flaground/backend/module/member/service/MemberScheduleService.java
@@ -1,6 +1,6 @@
 package com.Flaground.backend.module.member.service;
 
-import com.Flaground.backend.infra.aws.ses.service.MailService;
+import com.Flaground.backend.infra.aws.ses.service.AwsSESServiceImpl;
 import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.domain.Sleeping;
 import com.Flaground.backend.module.member.domain.repository.MemberRepository;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 public class MemberScheduleService {
     private final MemberRepository memberRepository;
     private final SleepingRepository sleepingRepository;
-    private final MailService mailService;
+    private final AwsSESServiceImpl mailService;
 
     //@Scheduled(cron = "000000")
     public void selectingDeactivateMembers() {

--- a/src/main/java/com/Flaground/backend/module/member/service/MemberService.java
+++ b/src/main/java/com/Flaground/backend/module/member/service/MemberService.java
@@ -5,8 +5,8 @@ import com.Flaground.backend.global.exception.CustomException;
 import com.Flaground.backend.global.exception.ErrorCode;
 import com.Flaground.backend.global.utility.RandomGenerator;
 import com.Flaground.backend.infra.aws.s3.entity.enums.FileDirectory;
-import com.Flaground.backend.infra.aws.s3.service.AwsS3Service;
-import com.Flaground.backend.infra.aws.ses.service.MailService;
+import com.Flaground.backend.infra.aws.s3.service.AwsS3ServiceImpl;
+import com.Flaground.backend.infra.aws.ses.service.AwsSESServiceImpl;
 import com.Flaground.backend.module.member.controller.dto.response.*;
 import com.Flaground.backend.module.member.domain.Avatar;
 import com.Flaground.backend.module.member.domain.JoinMember;
@@ -17,6 +17,7 @@ import com.Flaground.backend.module.token.service.RecoveryTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,8 +30,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final RecoveryTokenService recoveryTokenService;
     private final SleepingService sleepingService;
-    private final MailService mailService;
-    private final AwsS3Service awsS3Service;
+    private final AwsSESServiceImpl mailService;
+    private final AwsS3ServiceImpl awsS3Service;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
@@ -63,6 +64,13 @@ public class MemberService {
     @Transactional(readOnly = true)
     public boolean isExistEmail(String email) {
         return memberRepository.existsByEmail(email) || sleepingService.existsByEmail(email);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int loginFailed(String loginId) {
+        Member member = findByLoginId(loginId);
+        member.loginFail();
+        return member.getFailCount();
     }
 
     public void withdraw(Long memberId, String password) {
@@ -106,7 +114,7 @@ public class MemberService {
     }
 
     public Member reactivateIfSleeping(String loginId) {
-        sleepingService.reactivateMember(loginId);
+        sleepingService.reactiveIfSleeping(loginId);
         return findByLoginId(loginId);
     }
 

--- a/src/main/java/com/Flaground/backend/module/member/service/MemberService.java
+++ b/src/main/java/com/Flaground/backend/module/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public AvatarResponse getMemberPageAvatar(String loginId) {
         Member member = findByLoginId(loginId);
-        member.isAvailable();
+        member.isWithdraw();
         return AvatarResponse.of(member);
     }
 
@@ -51,7 +51,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public SearchResponse searchMember(String name) {
+    public SearchResponse<SearchMemberResponse> searchMember(String name) {
         return memberRepository.searchMemberByName(name);
     }
 

--- a/src/main/java/com/Flaground/backend/module/member/service/SleepingService.java
+++ b/src/main/java/com/Flaground/backend/module/member/service/SleepingService.java
@@ -21,12 +21,12 @@ public class SleepingService {
     }
 
     @Transactional
-    public void reactivateMember(String loginId) {
+    public void reactivateMember(String loginId) { // todo: 불필요한 삭제쿼리 발생
         reactiveIfPresent(loginId);
         sleepingRepository.deleteByLoginId(loginId);
     }
 
-    private void reactiveIfPresent(String loginId) {
+    private void reactiveIfPresent(String loginId) { // todo: reactive 되는지 테스트 작성하기
         sleepingRepository.findByLoginId(loginId)
                 .ifPresent(Sleeping::reactivate);
     }

--- a/src/main/java/com/Flaground/backend/module/member/service/SleepingService.java
+++ b/src/main/java/com/Flaground/backend/module/member/service/SleepingService.java
@@ -1,6 +1,5 @@
 package com.Flaground.backend.module.member.service;
 
-import com.Flaground.backend.module.member.domain.Sleeping;
 import com.Flaground.backend.module.member.domain.repository.SleepingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,13 +20,11 @@ public class SleepingService {
     }
 
     @Transactional
-    public void reactivateMember(String loginId) { // todo: 불필요한 삭제쿼리 발생
-        reactiveIfPresent(loginId);
-        sleepingRepository.deleteByLoginId(loginId);
-    }
-
-    private void reactiveIfPresent(String loginId) { // todo: reactive 되는지 테스트 작성하기
+    public void reactiveIfSleeping(String loginId) {
         sleepingRepository.findByLoginId(loginId)
-                .ifPresent(Sleeping::reactivate);
+                .ifPresent(sleeping -> {
+                    sleeping.reactivate();
+                    sleepingRepository.deleteByLoginId(loginId);
+                });
     }
 }

--- a/src/main/java/com/Flaground/backend/module/post/controller/PostController.java
+++ b/src/main/java/com/Flaground/backend/module/post/controller/PostController.java
@@ -104,7 +104,7 @@ public class PostController {
     @ResponseStatus(OK)
     @GetMapping("/search")
     public ApplicationResponse<SearchResponse> searchPostsWithCondition(@ModelAttribute @Valid SearchRequest request) {
-        SearchResponse responses = postService
+        SearchResponse<PostResponse> responses = postService
                 .searchPostsWithCondition(request.getBoard(), request.getKeyword(), request.getPeriod(), request.getOption());
         return new ApplicationResponse<>(responses);
     }
@@ -114,7 +114,7 @@ public class PostController {
     @ResponseStatus(OK)
     @GetMapping("/integration-search")
     public ApplicationResponse<SearchResponse> integrationSearch(@RequestParam @NotBlank String keyword) {
-        SearchResponse response = postService.integrationSearch(keyword);
+        SearchResponse<PostResponse> response = postService.integrationSearch(keyword);
         return new ApplicationResponse<>(response);
     }
 

--- a/src/main/java/com/Flaground/backend/module/post/controller/dto/request/CreateReplyRequest.java
+++ b/src/main/java/com/Flaground/backend/module/post/controller/dto/request/CreateReplyRequest.java
@@ -1,7 +1,10 @@
 package com.Flaground.backend.module.post.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 

--- a/src/main/java/com/Flaground/backend/module/post/domain/enums/SearchPeriod.java
+++ b/src/main/java/com/Flaground/backend/module/post/domain/enums/SearchPeriod.java
@@ -3,7 +3,6 @@ package com.Flaground.backend.module.post.domain.enums;
 import com.Flaground.backend.global.common.CustomEnumDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -12,7 +11,7 @@ import static com.Flaground.backend.module.post.domain.QPost.post;
 
 @RequiredArgsConstructor
 @JsonDeserialize(using = CustomEnumDeserializer.class)
-public enum SearchPeriod {
+public enum SearchPeriod { // todo : 기간 조건 반대로
     ALL(null),
     DAY(post.createdAt.before(LocalDateTime.now().minusDays(1))),
     WEEK(post.createdAt.before(LocalDateTime.now().minusWeeks(1))),

--- a/src/main/java/com/Flaground/backend/module/post/domain/enums/SearchPeriod.java
+++ b/src/main/java/com/Flaground/backend/module/post/domain/enums/SearchPeriod.java
@@ -11,13 +11,13 @@ import static com.Flaground.backend.module.post.domain.QPost.post;
 
 @RequiredArgsConstructor
 @JsonDeserialize(using = CustomEnumDeserializer.class)
-public enum SearchPeriod { // todo : 기간 조건 반대로
+public enum SearchPeriod {
     ALL(null),
-    DAY(post.createdAt.before(LocalDateTime.now().minusDays(1))),
-    WEEK(post.createdAt.before(LocalDateTime.now().minusWeeks(1))),
-    MONTH(post.createdAt.before(LocalDateTime.now().minusMonths(1))),
-    HALF_YEAR(post.createdAt.before(LocalDateTime.now().minusMonths(6))),
-    YEAR(post.createdAt.before(LocalDateTime.now().minusYears(1)));
+    DAY(post.createdAt.after(LocalDateTime.now().minusDays(1))),
+    WEEK(post.createdAt.after(LocalDateTime.now().minusWeeks(1))),
+    MONTH(post.createdAt.after(LocalDateTime.now().minusMonths(1))),
+    HALF_YEAR(post.createdAt.after(LocalDateTime.now().minusMonths(6))),
+    YEAR(post.createdAt.after(LocalDateTime.now().minusYears(1)));
 
     private final BooleanExpression periodExpression;
 

--- a/src/main/java/com/Flaground/backend/module/post/domain/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/Flaground/backend/module/post/domain/repository/PostRepositoryCustom.java
@@ -20,7 +20,7 @@ public interface PostRepositoryCustom {
 
     List<PostResponse> getTopFiveByCondition(TopPostCondition condition);
 
-    SearchResponse integrationSearch(String keyword);
+    SearchResponse<PostResponse> integrationSearch(String keyword);
 
-    SearchResponse searchWithCondition(String boardName, String keyword, SearchPeriod period, SearchOption option);
+    SearchResponse<PostResponse> searchWithCondition(String boardName, String keyword, SearchPeriod period, SearchOption option);
 }

--- a/src/main/java/com/Flaground/backend/module/post/domain/repository/implementation/PostRepositoryImpl.java
+++ b/src/main/java/com/Flaground/backend/module/post/domain/repository/implementation/PostRepositoryImpl.java
@@ -108,7 +108,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public SearchResponse integrationSearch(String keyword) {
+    public SearchResponse<PostResponse> integrationSearch(String keyword) {
         List<PostResponse> result = queryFactory
                 .select(new QPostResponse(
                         post.id,
@@ -131,7 +131,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public SearchResponse searchWithCondition(String boardName, String keyword, SearchPeriod period, SearchOption option) {
+    public SearchResponse<PostResponse> searchWithCondition(String boardName, String keyword, SearchPeriod period, SearchOption option) {
         JPAQuery<PostResponse> query = queryFactory
                 .selectDistinct(new QPostResponse(
                         post.id,

--- a/src/main/java/com/Flaground/backend/module/post/service/PostService.java
+++ b/src/main/java/com/Flaground/backend/module/post/service/PostService.java
@@ -42,7 +42,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<PostResponse> getMemberPagePosts(String loginId) {
         Member member = memberService.findByLoginId(loginId);
-        member.isAvailable();
+        member.isWithdraw();
         return postRepository.getPostsByLoginId(loginId);
     }
 
@@ -52,14 +52,14 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public SearchResponse searchPostsWithCondition(String boardName, String keyword,
+    public SearchResponse<PostResponse> searchPostsWithCondition(String boardName, String keyword,
                                                    SearchPeriod period, SearchOption option) {
         boardService.isCorrectName(boardName);
         return postRepository.searchWithCondition(boardName, keyword, period, option);
     }
 
     @Transactional(readOnly = true) // todo: pagination
-    public SearchResponse integrationSearch(String keyword) {
+    public SearchResponse<PostResponse> integrationSearch(String keyword) {
         return postRepository.integrationSearch(keyword);
     }
 

--- a/src/main/java/com/Flaground/backend/module/post/service/PostService.java
+++ b/src/main/java/com/Flaground/backend/module/post/service/PostService.java
@@ -58,7 +58,7 @@ public class PostService {
         return postRepository.searchWithCondition(boardName, keyword, period, option);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true) // todo: pagination
     public SearchResponse integrationSearch(String keyword) {
         return postRepository.integrationSearch(keyword);
     }
@@ -122,7 +122,7 @@ public class PostService {
         return replyService.dislike(memberId, replyId);
     }
 
-    private Post findById(Long postId) {
+    public Post findById(Long postId) {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
     }

--- a/src/main/java/com/Flaground/backend/module/post/service/ReplyService.java
+++ b/src/main/java/com/Flaground/backend/module/post/service/ReplyService.java
@@ -44,7 +44,7 @@ public class ReplyService {
         return reply;
     }
 
-    private Reply findById(Long replyId) {
+    public Reply findById(Long replyId) {
         return replyRepository.findById(replyId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REPLY_NOT_FOUND));
     }

--- a/src/main/java/com/Flaground/backend/module/report/controller/ReportController.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/ReportController.java
@@ -2,8 +2,8 @@ package com.Flaground.backend.module.report.controller;
 
 import com.Flaground.backend.global.common.response.ApplicationResponse;
 import com.Flaground.backend.global.utility.SecurityUtils;
-import com.Flaground.backend.module.report.controller.dto.request.ContentReportRequest;
 import com.Flaground.backend.module.report.controller.dto.request.MemberReportRequest;
+import com.Flaground.backend.module.report.controller.dto.request.ContentReportRequest;
 import com.Flaground.backend.module.report.controller.mapper.ReportMapper;
 import com.Flaground.backend.module.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,15 +40,30 @@ public class ReportController {
     }
 
     @Tag(name = "report")
-    @Operation(summary = "게시글/댓글 신고하기", description = "[토큰필요] type을 지정해줘야한다.")
+    @Operation(summary = "게시글 신고하기", description = "[토큰필요] type을 지정해줘야한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "신고 완료"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글입니다."),
             @ApiResponse(responseCode = "409", description = "이미 신고한 대상입니다.")
     })
     @ResponseStatus(CREATED)
-    @PostMapping("/content")
-    public ApplicationResponse reportContent(@RequestBody @Valid ContentReportRequest request) {
-        reportService.reportContent(SecurityUtils.getMemberId(), reportMapper.mapFrom(request));
+    @PostMapping("/post")
+    public ApplicationResponse reportPost(@RequestBody @Valid ContentReportRequest request) {
+        reportService.reportPost(SecurityUtils.getMemberId(), reportMapper.mapFrom(request));
+        return new ApplicationResponse<>();
+    }
+
+    @Tag(name = "report")
+    @Operation(summary = "댓글 신고하기", description = "[토큰필요] type을 지정해줘야한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "신고 완료"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 댓글입니다."),
+            @ApiResponse(responseCode = "409", description = "이미 신고한 대상입니다.")
+    })
+    @ResponseStatus(CREATED)
+    @PostMapping("/reply")
+    public ApplicationResponse reportReply(@RequestBody @Valid ContentReportRequest request) {
+        reportService.reportReply(SecurityUtils.getMemberId(), reportMapper.mapFrom(request));
         return new ApplicationResponse<>();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/request/ContentReportRequest.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/request/ContentReportRequest.java
@@ -9,11 +9,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ContentReportRequest {
     @Schema(name = "신고 대상의 번호(Id)")
     @NotNull
@@ -27,8 +26,8 @@ public class ContentReportRequest {
     @EnumFormat(enumClass = ReportCategory.class)
     private ReportCategory reportCategory;
 
-    @Schema(name = "신고 대상 Id")
-    @NotBlank
+    @Schema(name = "신고 상세 내용")
+    @NotNull
     private String detailExplanation;
 
     @Builder

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/request/MemberReportRequest.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/request/MemberReportRequest.java
@@ -9,25 +9,26 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberReportRequest {
     @Schema(name = "신고 대상 로그인 ID")
     @NotBlank
-    private String target;
+    private String loginId;
 
     @Schema(name = "신고 카테고리", example = "음란물 / 홍보 / 도배 / 욕설 / 개인정보 / 기타")
     @EnumFormat(enumClass = ReportCategory.class)
     private ReportCategory reportCategory;
 
-    @Schema(name = "신고 대상 Id")
-    @NotBlank
+    @Schema(name = "신고 상세 내용")
+    @NotNull
     private String detailExplanation;
 
     @Builder
-    public MemberReportRequest(String target, ReportCategory reportCategory, String detailExplanation) {
-        this.target = target;
+    public MemberReportRequest(String loginId, ReportCategory reportCategory, String detailExplanation) {
+        this.loginId = loginId;
         this.reportCategory = reportCategory;
         this.detailExplanation = detailExplanation;
     }

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/MemberReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/MemberReportResponse.java
@@ -1,0 +1,24 @@
+package com.Flaground.backend.module.report.controller.dto.response;
+
+import com.Flaground.backend.module.report.domain.enums.ReportCategory;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberReportResponse {
+    private Long reported;
+    private String loginId;
+    private ReportCategory reportCategory;
+    private String detailExplanation;
+
+    @QueryProjection
+    public MemberReportResponse(Long reported, String loginId, ReportCategory reportCategory, String detailExplanation) {
+        this.reported = reported;
+        this.loginId = loginId;
+        this.reportCategory = reportCategory;
+        this.detailExplanation = detailExplanation;
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/MemberReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/MemberReportResponse.java
@@ -9,13 +9,16 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberReportResponse {
+    private Long id;
     private Long reported;
     private String loginId;
     private ReportCategory reportCategory;
     private String detailExplanation;
 
     @QueryProjection
-    public MemberReportResponse(Long reported, String loginId, ReportCategory reportCategory, String detailExplanation) {
+    public MemberReportResponse(Long id, Long reported, String loginId,
+                                ReportCategory reportCategory, String detailExplanation) {
+        this.id = id;
         this.reported = reported;
         this.loginId = loginId;
         this.reportCategory = reportCategory;

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/PostReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/PostReportResponse.java
@@ -9,18 +9,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostReportResponse {
+    private Long id;
     private Long reported;
-    private Long postId;
     private String board;
+    private Long postId;
     private ReportCategory reportCategory;
     private String detailExplanation;
 
     @QueryProjection
-    public PostReportResponse(Long reported, Long postId, String board, ReportCategory reportCategory,
-                              String detailExplanation) {
+    public PostReportResponse(Long id, Long reported, String board, Long postId,
+                              ReportCategory reportCategory, String detailExplanation) {
+        this.id = id;
         this.reported = reported;
-        this.postId = postId;
         this.board = board;
+        this.postId = postId;
         this.reportCategory = reportCategory;
         this.detailExplanation = detailExplanation;
     }

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/PostReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/PostReportResponse.java
@@ -1,0 +1,27 @@
+package com.Flaground.backend.module.report.controller.dto.response;
+
+import com.Flaground.backend.module.report.domain.enums.ReportCategory;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostReportResponse {
+    private Long reported;
+    private Long postId;
+    private String board;
+    private ReportCategory reportCategory;
+    private String detailExplanation;
+
+    @QueryProjection
+    public PostReportResponse(Long reported, Long postId, String board, ReportCategory reportCategory,
+                              String detailExplanation) {
+        this.reported = reported;
+        this.postId = postId;
+        this.board = board;
+        this.reportCategory = reportCategory;
+        this.detailExplanation = detailExplanation;
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReplyReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReplyReportResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReplyReportResponse {
+    private Long id;
     private Long reported;
     private Long postId;
     private Long replyId;
@@ -17,8 +18,9 @@ public class ReplyReportResponse {
     private String detailExplanation;
 
     @QueryProjection
-    public ReplyReportResponse(Long reported, Long postId, Long replyId, ReportCategory reportCategory,
-                               String detailExplanation) {
+    public ReplyReportResponse(Long id, Long reported, Long postId, Long replyId,
+                               ReportCategory reportCategory, String detailExplanation) {
+        this.id = id;
         this.reported = reported;
         this.postId = postId;
         this.replyId = replyId;

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReplyReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReplyReportResponse.java
@@ -1,0 +1,28 @@
+package com.Flaground.backend.module.report.controller.dto.response;
+
+
+import com.Flaground.backend.module.report.domain.enums.ReportCategory;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReplyReportResponse {
+    private Long reported;
+    private Long postId;
+    private Long replyId;
+    private ReportCategory reportCategory;
+    private String detailExplanation;
+
+    @QueryProjection
+    public ReplyReportResponse(Long reported, Long postId, Long replyId, ReportCategory reportCategory,
+                               String detailExplanation) {
+        this.reported = reported;
+        this.postId = postId;
+        this.replyId = replyId;
+        this.reportCategory = reportCategory;
+        this.detailExplanation = detailExplanation;
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReportResponse.java
@@ -1,6 +1,9 @@
 package com.Flaground.backend.module.report.controller.dto.response;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 

--- a/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReportResponse.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/dto/response/ReportResponse.java
@@ -1,29 +1,20 @@
 package com.Flaground.backend.module.report.controller.dto.response;
 
-import com.Flaground.backend.module.report.domain.enums.ReportCategory;
-import com.Flaground.backend.module.report.domain.enums.ReportType;
-import com.querydsl.core.annotations.QueryProjection;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class ReportResponse {
-    private Long reported;
-    private String type;
-    private String category;
-    private String detailReason;
-    private LocalDateTime createdAt;
+    private List<MemberReportResponse> memberReportResponses;
+    private List<PostReportResponse> postReportResponses;
+    private List<ReplyReportResponse> replyReportResponses;
 
-    @QueryProjection
-    public ReportResponse(Long reported, ReportType type, ReportCategory category, String detailReason, LocalDateTime createdAt) {
-        this.reported = reported;
-        this.type = type.getType();
-        this.category = category.toString();
-        this.detailReason = detailReason;
-        this.createdAt = createdAt;
+    public static ReportResponse of(List<MemberReportResponse> memberReportResponses,
+                                    List<PostReportResponse> postReportResponses,
+                                    List<ReplyReportResponse> replyReportResponses) {
+        return new ReportResponse(memberReportResponses, postReportResponses, replyReportResponses);
     }
 }

--- a/src/main/java/com/Flaground/backend/module/report/controller/mapper/ReportMapper.java
+++ b/src/main/java/com/Flaground/backend/module/report/controller/mapper/ReportMapper.java
@@ -2,19 +2,22 @@ package com.Flaground.backend.module.report.controller.mapper;
 
 import com.Flaground.backend.module.report.controller.dto.request.ContentReportRequest;
 import com.Flaground.backend.module.report.controller.dto.request.MemberReportRequest;
-import com.Flaground.backend.module.report.domain.ReportData;
+import com.Flaground.backend.module.report.domain.AbstractReport;
 import com.Flaground.backend.module.report.domain.enums.ReportType;
-import org.mapstruct.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
 @Mapper(
         componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.WARN
 )
 public interface ReportMapper {
-    ReportData<Long> mapFrom(ContentReportRequest request);
+    AbstractReport<Long> mapFrom(ContentReportRequest request);
 
     @Mapping(target = "reportType", expression = "java(getDefault())")
-    ReportData<String> mapFrom(MemberReportRequest request);
+    @Mapping(source = "loginId", target = "target")
+    AbstractReport<String> mapFrom(MemberReportRequest request);
 
     default ReportType getDefault() {
         return ReportType.MEMBER;

--- a/src/main/java/com/Flaground/backend/module/report/domain/AbstractReport.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/AbstractReport.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class ReportData<T> {
+public class AbstractReport<T> {
     private T target;
     private ReportType reportType;
     private ReportCategory reportCategory;

--- a/src/main/java/com/Flaground/backend/module/report/domain/MemberReport.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/MemberReport.java
@@ -1,0 +1,32 @@
+package com.Flaground.backend.module.report.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberReport extends Report {
+    @Column
+    private String loginId;
+
+    @Builder
+    public MemberReport(Long reporter, Long reported, ReportInfo reportInfo, String loginId) {
+        super(reporter, reported, reportInfo);
+        this.loginId = loginId;
+    }
+
+    public static MemberReport of(Long reporter, Long reported, AbstractReport<String> abstractReport) {
+        return MemberReport.builder()
+                .reporter(reporter)
+                .reported(reported)
+                .loginId(abstractReport.getTarget())
+                .reportInfo(ReportInfo.from(abstractReport))
+                .build();
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/report/domain/PostReport.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/PostReport.java
@@ -1,0 +1,38 @@
+package com.Flaground.backend.module.report.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostReport extends Report {
+    @Column
+    private String board;
+
+    @Column(name = "post_id")
+    private Long postId;
+
+    @Builder
+    public PostReport(Long reporter, Long reported, ReportInfo reportInfo, String board, Long postId) {
+        super(reporter, reported, reportInfo);
+        this.board = board;
+        this.postId = postId;
+    }
+
+    public static PostReport of(Long reporter, Long reported,
+                                String board , AbstractReport<Long> abstractReport) {
+        return PostReport.builder()
+                .reporter(reporter)
+                .reported(reported)
+                .board(board)
+                .postId(abstractReport.getTarget())
+                .reportInfo(ReportInfo.from(abstractReport))
+                .build();
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/report/domain/ReplyReport.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/ReplyReport.java
@@ -1,0 +1,38 @@
+package com.Flaground.backend.module.report.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReplyReport extends Report {
+    @Column(name = "post_id")
+    private Long postId;
+
+    @Column(name = "reply_id")
+    private Long replyId;
+
+    @Builder
+    public ReplyReport(Long reporter, Long reported, ReportInfo reportInfo, Long postId, Long replyId) {
+        super(reporter, reported, reportInfo);
+        this.postId = postId;
+        this.replyId = replyId;
+    }
+
+    public static ReplyReport of(Long reporter, Long reported, Long postId,
+                                 AbstractReport<Long> abstractReport) {
+        return ReplyReport.builder()
+                .reporter(reporter)
+                .reported(reported)
+                .postId(postId)
+                .replyId(abstractReport.getTarget())
+                .reportInfo(ReportInfo.from(abstractReport))
+                .build();
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/report/domain/Report.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/Report.java
@@ -1,19 +1,17 @@
 package com.Flaground.backend.module.report.domain;
 
-import com.Flaground.backend.module.report.domain.enums.ReportCategory;
-import com.Flaground.backend.module.report.domain.enums.ReportType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Report {
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class Report {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "report_id")
@@ -25,47 +23,12 @@ public class Report {
     @Column(name = "reported_id")
     private Long reported;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "type")
-    private ReportType reportType;
+    @Embedded
+    private ReportInfo reportInfo;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "category")
-    private ReportCategory reportCategory;
-
-    @Column(length = 300)
-    private String detailExplanation;
-
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @Builder
-    public Report(Long reporter, Long reported, ReportType reportType, ReportCategory reportCategory, String detailExplanation) {
+    public Report(Long reporter, Long reported, ReportInfo reportInfo) {
         this.reporter = reporter;
         this.reported = reported;
-        this.reportType = reportType;
-        this.reportCategory = reportCategory;
-        this.detailExplanation = detailExplanation;
-        this.createdAt = LocalDateTime.now();
-    }
-
-    public static Report member(Long reporter, Long reported, ReportData<String> reportData) {
-        return Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .reportType(reportData.getReportType())
-                .reportCategory(reportData.getReportCategory())
-                .detailExplanation(reportData.getDetailExplanation())
-                .build();
-    }
-
-    public static Report content(Long reporter, ReportData<Long> reportData) {
-        return Report.builder()
-                .reporter(reporter)
-                .reported(reportData.getTarget())
-                .reportType(reportData.getReportType())
-                .reportCategory(reportData.getReportCategory())
-                .detailExplanation(reportData.getDetailExplanation())
-                .build();
+        this.reportInfo = reportInfo;
     }
 }

--- a/src/main/java/com/Flaground/backend/module/report/domain/Report.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/Report.java
@@ -1,7 +1,6 @@
 package com.Flaground.backend.module.report.domain;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,5 +29,9 @@ public abstract class Report {
         this.reporter = reporter;
         this.reported = reported;
         this.reportInfo = reportInfo;
+    }
+
+    public int getPenalty() {
+        return reportInfo.getReportCategory().getPenaltyPoint();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/report/domain/ReportInfo.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/ReportInfo.java
@@ -1,0 +1,44 @@
+package com.Flaground.backend.module.report.domain;
+
+import com.Flaground.backend.module.report.domain.enums.ReportCategory;
+import com.Flaground.backend.module.report.domain.enums.ReportType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportInfo {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private ReportType reportType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category")
+    private ReportCategory reportCategory;
+
+    @Column(columnDefinition = "text")
+    private String detailExplanation;
+
+    @Builder
+    public ReportInfo(ReportType reportType, ReportCategory reportCategory, String detailExplanation) {
+        this.reportType = reportType;
+        this.reportCategory = reportCategory;
+        this.detailExplanation = detailExplanation;
+    }
+
+    public static ReportInfo from(AbstractReport<?> abstractReport) {
+        return ReportInfo.builder()
+                .reportType(abstractReport.getReportType())
+                .reportCategory(abstractReport.getReportCategory())
+                .detailExplanation(abstractReport.getDetailExplanation())
+                .build();
+    }
+}

--- a/src/main/java/com/Flaground/backend/module/report/domain/enums/ReportCategory.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/enums/ReportCategory.java
@@ -2,8 +2,10 @@ package com.Flaground.backend.module.report.domain.enums;
 
 import com.Flaground.backend.global.common.CustomEnumDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @JsonDeserialize(using = CustomEnumDeserializer.class)
 @RequiredArgsConstructor
 public enum ReportCategory {

--- a/src/main/java/com/Flaground/backend/module/report/domain/enums/ReportCategory.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/enums/ReportCategory.java
@@ -2,8 +2,17 @@ package com.Flaground.backend.module.report.domain.enums;
 
 import com.Flaground.backend.global.common.CustomEnumDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.RequiredArgsConstructor;
 
 @JsonDeserialize(using = CustomEnumDeserializer.class)
+@RequiredArgsConstructor
 public enum ReportCategory {
-    음란물, 홍보, 도배, 욕설, 개인정보, 기타;
+    음란물(5),
+    홍보(5),
+    도배(3),
+    욕설(3),
+    개인정보(10),
+    기타(3);
+
+    private final int penaltyPoint;
 }

--- a/src/main/java/com/Flaground/backend/module/report/domain/repository/ReportRepositoryCustom.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/repository/ReportRepositoryCustom.java
@@ -3,8 +3,6 @@ package com.Flaground.backend.module.report.domain.repository;
 import com.Flaground.backend.module.report.controller.dto.response.ReportResponse;
 import com.Flaground.backend.module.report.domain.enums.ReportType;
 
-import java.util.List;
-
 public interface ReportRepositoryCustom {
     boolean existByIdsAndType(Long reporter, Long reported, ReportType reportType);
     ReportResponse getReports();

--- a/src/main/java/com/Flaground/backend/module/report/domain/repository/ReportRepositoryCustom.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/repository/ReportRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface ReportRepositoryCustom {
     boolean existByIdsAndType(Long reporter, Long reported, ReportType reportType);
-    List<ReportResponse> getReports();
+    ReportResponse getReports();
 }

--- a/src/main/java/com/Flaground/backend/module/report/domain/repository/implementation/ReportRepositoryImpl.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/repository/implementation/ReportRepositoryImpl.java
@@ -34,6 +34,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 
     private List<MemberReportResponse> fetchMemberReports() {
         return queryFactory.select(new QMemberReportResponse(
+                        memberReport.id,
                         memberReport.reported,
                         memberReport.loginId,
                         memberReport.reportInfo.reportCategory,
@@ -45,9 +46,10 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 
     private List<PostReportResponse> fetchPostReports() {
         return queryFactory.select(new QPostReportResponse(
+                        postReport.id,
                         postReport.reported,
-                        postReport.postId,
                         postReport.board,
+                        postReport.postId,
                         postReport.reportInfo.reportCategory,
                         postReport.reportInfo.detailExplanation))
                 .from(postReport)
@@ -57,13 +59,14 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 
     private List<ReplyReportResponse> fetchReplyReports() {
         return queryFactory.select(new QReplyReportResponse(
+                        replyReport.id,
                         replyReport.reported,
                         replyReport.postId,
                         replyReport.replyId,
                         replyReport.reportInfo.reportCategory,
                         replyReport.reportInfo.detailExplanation))
                 .from(replyReport)
-                .orderBy(postReport.id.desc())
+                .orderBy(replyReport.id.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/report/domain/repository/implementation/ReportRepositoryImpl.java
+++ b/src/main/java/com/Flaground/backend/module/report/domain/repository/implementation/ReportRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.Flaground.backend.module.report.domain.repository.implementation;
 
-import com.Flaground.backend.module.report.controller.dto.response.QReportResponse;
-import com.Flaground.backend.module.report.controller.dto.response.ReportResponse;
+import com.Flaground.backend.module.report.controller.dto.response.*;
 import com.Flaground.backend.module.report.domain.enums.ReportType;
 import com.Flaground.backend.module.report.domain.repository.ReportRepositoryCustom;
 import com.querydsl.jpa.JPQLQueryFactory;
@@ -9,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import static com.Flaground.backend.module.report.domain.QMemberReport.memberReport;
+import static com.Flaground.backend.module.report.domain.QPostReport.postReport;
+import static com.Flaground.backend.module.report.domain.QReplyReport.replyReport;
 import static com.Flaground.backend.module.report.domain.QReport.report;
 
 @RequiredArgsConstructor
@@ -21,20 +23,47 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
                 .selectFrom(report)
                 .where(report.reporter.eq(reporter),
                         report.reported.eq(reported),
-                        report.reportType.eq(reportType))
+                        report.reportInfo.reportType.eq(reportType))
                 .fetchFirst() != null;
     }
 
     @Override
-    public List<ReportResponse> getReports() {
-        return queryFactory
-                .select(new QReportResponse(
-                        report.reported,
-                        report.reportType,
-                        report.reportCategory,
-                        report.detailExplanation,
-                        report.createdAt))
-                .from(report)
+    public ReportResponse getReports() {
+        return ReportResponse.of(fetchMemberReports(), fetchPostReports(), fetchReplyReports());
+    }
+
+    private List<MemberReportResponse> fetchMemberReports() {
+        return queryFactory.select(new QMemberReportResponse(
+                        memberReport.reported,
+                        memberReport.loginId,
+                        memberReport.reportInfo.reportCategory,
+                        memberReport.reportInfo.detailExplanation))
+                .from(memberReport)
+                .orderBy(memberReport.id.desc())
+                .fetch();
+    }
+
+    private List<PostReportResponse> fetchPostReports() {
+        return queryFactory.select(new QPostReportResponse(
+                        postReport.reported,
+                        postReport.postId,
+                        postReport.board,
+                        postReport.reportInfo.reportCategory,
+                        postReport.reportInfo.detailExplanation))
+                .from(postReport)
+                .orderBy(postReport.id.desc())
+                .fetch();
+    }
+
+    private List<ReplyReportResponse> fetchReplyReports() {
+        return queryFactory.select(new QReplyReportResponse(
+                        replyReport.reported,
+                        replyReport.postId,
+                        replyReport.replyId,
+                        replyReport.reportInfo.reportCategory,
+                        replyReport.reportInfo.detailExplanation))
+                .from(replyReport)
+                .orderBy(postReport.id.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/Flaground/backend/module/report/service/ReportService.java
+++ b/src/main/java/com/Flaground/backend/module/report/service/ReportService.java
@@ -4,39 +4,55 @@ import com.Flaground.backend.global.exception.CustomException;
 import com.Flaground.backend.global.exception.ErrorCode;
 import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.service.MemberService;
+import com.Flaground.backend.module.post.domain.Post;
+import com.Flaground.backend.module.post.domain.Reply;
+import com.Flaground.backend.module.post.service.PostService;
+import com.Flaground.backend.module.post.service.ReplyService;
 import com.Flaground.backend.module.report.controller.dto.response.ReportResponse;
-import com.Flaground.backend.module.report.domain.Report;
-import com.Flaground.backend.module.report.domain.ReportData;
+import com.Flaground.backend.module.report.domain.AbstractReport;
+import com.Flaground.backend.module.report.domain.MemberReport;
+import com.Flaground.backend.module.report.domain.PostReport;
+import com.Flaground.backend.module.report.domain.ReplyReport;
 import com.Flaground.backend.module.report.domain.enums.ReportType;
 import com.Flaground.backend.module.report.domain.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class ReportService {
     private final ReportRepository reportRepository;
     private final MemberService memberService;
+    private final PostService postService;
+    private final ReplyService replyService;
 
-    public List<ReportResponse> getReports() {
+    @Transactional(readOnly = true)
+    public ReportResponse getReports() {
         return reportRepository.getReports();
     }
 
-    @Transactional
-    public void reportMember(Long memberId, ReportData<String> reportData) {
-        Member reported = memberService.findByLoginId(reportData.getTarget());
-        validateDuplicate(memberId, reported.getId(), reportData.getReportType());
-        reportRepository.save(Report.member(memberId, reported.getId(), reportData));
+    public void reportMember(Long memberId, AbstractReport<String> abstractReport) {
+        Member reported = memberService.findByLoginId(abstractReport.getTarget());
+        validateDuplicate(memberId, reported.getId(), abstractReport.getReportType());
+        reportRepository.save(MemberReport.of(memberId, reported.getId(), abstractReport));
     }
 
-    @Transactional
-    public void reportContent(Long memberId, ReportData<Long> reportData) {
-        validateDuplicate(memberId, reportData.getTarget(), reportData.getReportType());
-        reportRepository.save(Report.content(memberId, reportData));
+    public void reportPost(Long memberId, AbstractReport<Long> abstractReport) {
+        Post post = postService.findById(abstractReport.getTarget());
+        validateDuplicate(memberId, post.getMember().getId(), abstractReport.getReportType());
+        reportRepository.save(PostReport.of(memberId, post.getMember().getId(), post.getBoardName(), abstractReport));
+    }
+
+    public void reportReply(Long memberId, AbstractReport<Long> abstractReport) {
+        Reply reply = replyService.findById(abstractReport.getTarget());
+        validateDuplicate(memberId, reply.getMember().getId(), abstractReport.getReportType());
+        reportRepository.save(ReplyReport.of(memberId, reply.getMember().getId(), reply.getPostId(), abstractReport));
+    }
+
+    public void delete(Long reportId) {
+        reportRepository.deleteById(reportId);
     }
 
     private void validateDuplicate(Long reporterId, Long reportedId, ReportType reportType) {

--- a/src/main/java/com/Flaground/backend/module/report/service/ReportService.java
+++ b/src/main/java/com/Flaground/backend/module/report/service/ReportService.java
@@ -9,10 +9,7 @@ import com.Flaground.backend.module.post.domain.Reply;
 import com.Flaground.backend.module.post.service.PostService;
 import com.Flaground.backend.module.post.service.ReplyService;
 import com.Flaground.backend.module.report.controller.dto.response.ReportResponse;
-import com.Flaground.backend.module.report.domain.AbstractReport;
-import com.Flaground.backend.module.report.domain.MemberReport;
-import com.Flaground.backend.module.report.domain.PostReport;
-import com.Flaground.backend.module.report.domain.ReplyReport;
+import com.Flaground.backend.module.report.domain.*;
 import com.Flaground.backend.module.report.domain.enums.ReportType;
 import com.Flaground.backend.module.report.domain.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +50,11 @@ public class ReportService {
 
     public void delete(Long reportId) {
         reportRepository.deleteById(reportId);
+    }
+
+    public Report findById(Long id) {
+        return reportRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.REPORT_NOT_FOUND));
     }
 
     private void validateDuplicate(Long reporterId, Long reportedId, ReportType reportType) {

--- a/src/main/java/com/Flaground/backend/module/token/domain/RefreshToken.java
+++ b/src/main/java/com/Flaground/backend/module/token/domain/RefreshToken.java
@@ -1,8 +1,10 @@
 package com.Flaground.backend.module.token.domain;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/Flaground/backend/module/token/dto/TokenRequest.java
+++ b/src/main/java/com/Flaground/backend/module/token/dto/TokenRequest.java
@@ -1,7 +1,10 @@
 package com.Flaground.backend.module.token.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 

--- a/src/test/java/com/Flaground/backend/common/IntegrationTest.java
+++ b/src/test/java/com/Flaground/backend/common/IntegrationTest.java
@@ -7,11 +7,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc
-@Transactional
 @SpringBootTest
 public class IntegrationTest {
     @Autowired

--- a/src/test/java/com/Flaground/backend/module/activity/ActivityControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/activity/ActivityControllerTest.java
@@ -4,15 +4,17 @@ package com.Flaground.backend.module.activity;
 import com.Flaground.backend.common.IntegrationTest;
 import com.Flaground.backend.module.activity.controller.dto.request.CreateActivityRequest;
 import com.Flaground.backend.module.activity.controller.dto.request.UpdateActivityRequest;
+import com.Flaground.backend.module.activity.controller.mapper.ActivityMapper;
 import com.Flaground.backend.module.activity.domain.Activity;
 import com.Flaground.backend.module.activity.domain.enums.ActivityType;
 import com.Flaground.backend.module.activity.domain.enums.BookUsage;
 import com.Flaground.backend.module.activity.domain.enums.Proceed;
-import com.Flaground.backend.module.activity.controller.mapper.ActivityMapper;
 import com.Flaground.backend.module.activity.domain.repository.ActivityRepository;
 import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.domain.enums.Role;
 import com.Flaground.backend.module.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ActivityControllerTest extends IntegrationTest {
+class ActivityControllerTest extends IntegrationTest {
     private static final String BASE_URL = "/activities";
 
     @Autowired
@@ -69,9 +71,16 @@ public class ActivityControllerTest extends IntegrationTest {
         setSecurityContext(member);
     }
 
+    @AfterEach
+    void clean() {
+        activityRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
     @Test
     public void 활동_생성_테스트() throws Exception {
         // given
+        activityRepository.deleteAllInBatch();
         setCreateActivityRequest();
 
         // when
@@ -176,6 +185,11 @@ public class ActivityControllerTest extends IntegrationTest {
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(principal, "", authorities));
     }
 
+    private void setActivity(Member member) {
+        setCreateActivityRequest();
+        activity = activityRepository.save(Activity.of(member, activityMapper.mapFrom(createActivityRequest)));
+    }
+
     private void setCreateActivityRequest() {
         final String name = "name";
         final String description = "description";
@@ -193,10 +207,5 @@ public class ActivityControllerTest extends IntegrationTest {
                 .bookUsage(bookUsage)
                 .bookName("")
                 .build();
-    }
-
-    private void setActivity(Member member) {
-        setCreateActivityRequest();
-        activity = activityRepository.save(Activity.of(member, activityMapper.mapFrom(createActivityRequest)));
     }
 }

--- a/src/test/java/com/Flaground/backend/module/activity/ActivityServiceTest.java
+++ b/src/test/java/com/Flaground/backend/module/activity/ActivityServiceTest.java
@@ -1,23 +1,22 @@
 package com.Flaground.backend.module.activity;
 
+import com.Flaground.backend.global.exception.CustomException;
+import com.Flaground.backend.global.exception.ErrorCode;
 import com.Flaground.backend.module.activity.controller.dto.response.ActivityApplyResponse;
-import com.Flaground.backend.module.activity.domain.ActivityApply;
-import com.Flaground.backend.module.activity.domain.repository.ActivityApplyRepository;
 import com.Flaground.backend.module.activity.controller.dto.response.GetAllActivitiesResponse;
+import com.Flaground.backend.module.activity.controller.dto.response.ParticipantResponse;
 import com.Flaground.backend.module.activity.domain.Activity;
+import com.Flaground.backend.module.activity.domain.ActivityApply;
 import com.Flaground.backend.module.activity.domain.ActivityInfo;
 import com.Flaground.backend.module.activity.domain.enums.ActivityStatus;
 import com.Flaground.backend.module.activity.domain.enums.ActivityType;
 import com.Flaground.backend.module.activity.domain.enums.Proceed;
-import com.Flaground.backend.module.activity.controller.mapper.ActivityMapper;
-import com.Flaground.backend.module.activity.controller.dto.response.ParticipantResponse;
-import com.Flaground.backend.module.activity.domain.repository.MemberActivityRepository;
+import com.Flaground.backend.module.activity.domain.repository.ActivityApplyRepository;
 import com.Flaground.backend.module.activity.domain.repository.ActivityRepository;
+import com.Flaground.backend.module.activity.domain.repository.MemberActivityRepository;
 import com.Flaground.backend.module.activity.service.ActivityService;
 import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.domain.repository.MemberRepository;
-import com.Flaground.backend.global.exception.CustomException;
-import com.Flaground.backend.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -52,9 +51,6 @@ public class ActivityServiceTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private ActivityMapper activityMapper;
 
     @Autowired
     private EntityManager entityManager;

--- a/src/test/java/com/Flaground/backend/module/auth/AuthControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/auth/AuthControllerTest.java
@@ -1,47 +1,115 @@
 package com.Flaground.backend.module.auth;
 
 import com.Flaground.backend.common.IntegrationTest;
-import com.Flaground.backend.module.auth.domain.repository.AuthRepository;
+import com.Flaground.backend.global.exception.ErrorCode;
+import com.Flaground.backend.module.auth.controller.dto.request.LoginRequest;
+import com.Flaground.backend.module.member.domain.Member;
+import com.Flaground.backend.module.member.domain.enums.Role;
+import com.Flaground.backend.module.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.ResultActions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class AuthControllerTest extends IntegrationTest {
+class AuthControllerTest extends IntegrationTest {
     private static final String BASE_URI = "/auth";
-    @Autowired
-    private AuthRepository authRepository;
 
-//    @Test
-//    public void 인증시간_만료로_회원가입_실패() throws Exception {
-//        // given
-//        final String email = "gmlwh124@suwon.ac.kr";
-//        final String certification = RandomGenerator.getRandomNumber();
-//        final LocalDateTime expireAt = LocalDateTime.now().minusMinutes(10);
-//
-//        AuthInformation authInformation = AuthInformation.builder()
-//                .email(email)
-//                .joinType(JoinType.NORMAL)
-//                .certification(certification)
-//                .build();
-//
-//        authInformation.setCreatedAt(expireAt);
-//        authRepository.save(authInformation);
-//
-//        SignUpRequest request = SignUpRequest.builder().email(email).certification(certification).build();
-//        String uri = BASE_URI + "/sign-up";
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(post(uri)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(request)));
-//
-//        // then
-//        resultActions
-//                .andExpect(status().isBadRequest())
-//                .andExpect(jsonPath("errorCode").value(ErrorCode.EXPIRED_AUTHENTICATION_TIME.toString()))
-//                .andExpect(jsonPath("message").value(ErrorCode.EXPIRED_AUTHENTICATION_TIME.getMessage()))
-//                .andDo(print());
-//    }
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Nested
+    class 로그인_실패_테스트 {
+        final String loginId = "gmlwh124";
+        final String password = "qwer1234!";
+        final Role role = Role.ROLE_USER;
+        final String uri = BASE_URI + "/login";
+
+        private Member member;
+
+        private LoginRequest request;
+
+        private void initRequest(String password) {
+            request = LoginRequest.builder().loginId(loginId).password(password).build();
+        }
+
+        @BeforeEach
+        void setup() {
+            member = memberRepository.save(Member.builder()
+                    .loginId(loginId)
+                    .password(passwordEncoder.encode(password))
+                    .role(role)
+                    .build());
+        }
+
+        @Test
+        void 비밀번호_불일치_테스트() throws Exception {
+            // given
+            final int expectFailCount = 1;
+            final String wrongPassword = "wert2345@";
+            initRequest(wrongPassword);
+
+            // when
+            mockMvc.perform(post(uri)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value(ErrorCode.PASSWORD_NOT_MATCH.toString()))
+                    .andExpect(jsonPath("message").value(ErrorCode.PASSWORD_NOT_MATCH.getMessage()))
+                    .andExpect(jsonPath("payload", is(expectFailCount)))
+                    .andDo(print());
+
+            // then
+            Member findMember = memberRepository.findByLoginId(loginId).orElse(null);
+            assertThat(findMember.getIssueRecord().getLoginFailCount()).isEqualTo(expectFailCount);
+        }
+
+        @Test
+        void 계정_잠금_실패_테스트() throws Exception {
+            // given
+            member.lock();
+            initRequest(password);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(uri)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value(ErrorCode.LOCKED_ACCOUNT.toString()))
+                    .andExpect(jsonPath("message").value(ErrorCode.LOCKED_ACCOUNT.getMessage()))
+                    .andDo(print());
+        }
+
+        @Test
+        void 계정_비활성화_실패_테스트() throws Exception {
+            // given
+            member.ban();
+            initRequest(password);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(uri)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value(ErrorCode.BANNED_ACCOUNT.toString()))
+                    .andExpect(jsonPath("message").value(ErrorCode.BANNED_ACCOUNT.getMessage()))
+                    .andDo(print());
+        }
+    }
 }

--- a/src/test/java/com/Flaground/backend/module/auth/AuthServiceSliceTest.java
+++ b/src/test/java/com/Flaground/backend/module/auth/AuthServiceSliceTest.java
@@ -7,7 +7,7 @@ import com.Flaground.backend.module.auth.domain.AuthInformation;
 import com.Flaground.backend.module.auth.domain.repository.AuthRepository;
 import com.Flaground.backend.module.auth.service.AuthService;
 import com.Flaground.backend.module.member.service.MemberService;
-import com.Flaground.backend.infra.aws.ses.service.MailService;
+import com.Flaground.backend.infra.aws.ses.service.AwsSESServiceImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -21,7 +21,7 @@ public class AuthServiceSliceTest extends MockServiceTest {
     private AuthService authService;
 
     @Mock
-    private MailService mailService;
+    private AwsSESServiceImpl mailService;
 
     @Mock
     private AuthRepository authRepository;

--- a/src/test/java/com/Flaground/backend/module/auth/AuthServiceTest.java
+++ b/src/test/java/com/Flaground/backend/module/auth/AuthServiceTest.java
@@ -14,22 +14,19 @@ import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.domain.enums.Role;
 import com.Flaground.backend.module.member.domain.repository.MemberRepository;
 import com.Flaground.backend.module.token.dto.TokenResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.transaction.annotation.Transactional;
-
-import javax.persistence.EntityManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest
-@Transactional
-public class AuthServiceTest {
+class AuthServiceTest {
     @Autowired
     private AuthService authService;
 
@@ -48,8 +45,10 @@ public class AuthServiceTest {
     @Autowired
     private JwtUtilizer jwtUtilizer;
 
-    @Autowired
-    private EntityManager entityManager;
+    @AfterEach
+    void cleanUp() {
+        memberRepository.deleteAllInBatch();
+    }
 
     @Test
     void 아이디_유효성_검사_테스트() {
@@ -169,7 +168,6 @@ public class AuthServiceTest {
 
         // when
         TokenResponse tokenResponse = authService.login(loginId, password);
-        entityManager.clear(); // update query
 
         // then
         assertThat(tokenResponse.getAccessToken()).isNotNull();

--- a/src/test/java/com/Flaground/backend/module/board/BoardControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/board/BoardControllerTest.java
@@ -8,6 +8,7 @@ import com.Flaground.backend.module.member.domain.Avatar;
 import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.domain.enums.Role;
 import com.Flaground.backend.module.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class BoardControllerTest extends IntegrationTest {
+class BoardControllerTest extends IntegrationTest {
     private static final String BASE_URI = "/boards";
     @Autowired
     private MemberRepository memberRepository;
@@ -57,6 +58,12 @@ public class BoardControllerTest extends IntegrationTest {
 
         board = boardRepository.save(Board.builder().boardType(boardType).name(boardName).build());
         setSecurityContext(member);
+    }
+
+    @AfterEach
+    void clean() {
+        memberRepository.deleteAllInBatch();
+        boardRepository.deleteAllInBatch();
     }
 
     @Test

--- a/src/test/java/com/Flaground/backend/module/member/MemberControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/MemberControllerTest.java
@@ -8,6 +8,7 @@ import com.Flaground.backend.module.member.domain.enums.MemberStatus;
 import com.Flaground.backend.module.member.domain.enums.Role;
 import com.Flaground.backend.module.member.domain.repository.MemberRepository;
 import com.Flaground.backend.global.exception.CustomException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,8 +29,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class MemberControllerTest extends IntegrationTest {
+class MemberControllerTest extends IntegrationTest {
     private static final String BASE_URI = "/members";
+    
     @Autowired
     private MemberRepository memberRepository;
 
@@ -55,6 +57,11 @@ public class MemberControllerTest extends IntegrationTest {
                 .build());
     }
 
+    @AfterEach
+    void clean() {
+        memberRepository.deleteAllInBatch();
+    }
+
     @Test
     public void 유저_탈퇴_테스트() throws Exception {
         // given
@@ -75,7 +82,8 @@ public class MemberControllerTest extends IntegrationTest {
         // then
         Member withdrawMember = memberRepository.findById(member.getId()).get();
         assertThat(withdrawMember.getStatus()).isEqualTo(MemberStatus.WITHDRAW);
-        assertThatExceptionOfType(CustomException.class).isThrownBy(withdrawMember::isWithdraw);
+        assertThatExceptionOfType(CustomException.class)
+                .isThrownBy(withdrawMember::isWithdraw);
     }
 
     private void setSecurityContext(Member member) {

--- a/src/test/java/com/Flaground/backend/module/member/MemberControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/MemberControllerTest.java
@@ -75,7 +75,7 @@ public class MemberControllerTest extends IntegrationTest {
         // then
         Member withdrawMember = memberRepository.findById(member.getId()).get();
         assertThat(withdrawMember.getStatus()).isEqualTo(MemberStatus.WITHDRAW);
-        assertThatExceptionOfType(CustomException.class).isThrownBy(withdrawMember::isAvailable);
+        assertThatExceptionOfType(CustomException.class).isThrownBy(withdrawMember::isWithdraw);
     }
 
     private void setSecurityContext(Member member) {

--- a/src/test/java/com/Flaground/backend/module/member/MemberServiceSliceTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/MemberServiceSliceTest.java
@@ -2,7 +2,7 @@ package com.Flaground.backend.module.member;
 
 import com.Flaground.backend.common.MockServiceTest;
 import com.Flaground.backend.global.utility.RandomGenerator;
-import com.Flaground.backend.infra.aws.ses.service.MailService;
+import com.Flaground.backend.infra.aws.ses.service.AwsSESServiceImpl;
 import com.Flaground.backend.module.member.controller.dto.response.RecoveryResponse;
 import com.Flaground.backend.module.member.controller.dto.response.RecoveryResultResponse;
 import com.Flaground.backend.module.member.domain.Member;
@@ -29,7 +29,7 @@ public class MemberServiceSliceTest extends MockServiceTest {
     private MemberService memberService;
 
     @Mock
-    private MailService mailService;
+    private AwsSESServiceImpl mailService;
 
     @Mock
     private MemberRepository memberRepository;

--- a/src/test/java/com/Flaground/backend/module/member/MemberServiceTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/MemberServiceTest.java
@@ -224,7 +224,7 @@ public class MemberServiceTest {
     }
 
     @Test
-    public void 휴면계정_활성화_테스트() {
+    void 휴면계정_활성화_테스트() {
         // given
         final String loginId = "gmlwh124";
         initAvatar();

--- a/src/test/java/com/Flaground/backend/module/member/MemberServiceTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/MemberServiceTest.java
@@ -99,7 +99,7 @@ public class MemberServiceTest {
             Member findMember = memberRepository.findById(savedMember.getId()).get();
             assertThat(findMember.getStatus()).isEqualTo(withdraw);
             assertThatExceptionOfType(CustomException.class)
-                    .isThrownBy(findMember::isAvailable)
+                    .isThrownBy(findMember::isWithdraw)
                     .withMessage(ErrorCode.UNAVAILABLE_ACCOUNT.getMessage());
         }
 
@@ -244,31 +244,6 @@ public class MemberServiceTest {
         assertThat(reactivateMember.getAvatar().getStudentId()).isNull();
         assertThat(reactivateMember.getAvatar().getMajor()).isNull();
     }
-
-//    @Test
-//    @DisplayName("로그보기")
-//    void viewLogTest() {
-//        //given
-//        String loginId = "minjung123";
-//        String name = "김민정";
-//        LocalDateTime lastLoginTime = LocalDateTime.of(2023,2,5,2,59);
-//
-//        Member member = memberRepository.save(Member.builder()
-//                .loginId(loginId)
-//                .name(name)
-//                .lastLoginTime(lastLoginTime)
-//                .build());
-//
-//        //when
-//        List<LoginLogResponse> memberList = memberService.getAllLoginLogs();
-//
-//        //then
-//        LoginLogResponse testMember = memberList.get(0);
-//
-//        assertThat(testMember.getId()).isEqualTo(member.getId());
-//        assertThat(testMember.getName()).isEqualTo(member.getName());
-//        assertThat(testMember.getLastLoginTime()).isEqualTo(member.getLastLoginTime());
-//    }
 
     private void initAvatar() {
         final String nickname = "john";

--- a/src/test/java/com/Flaground/backend/module/member/SleepingRepositoryTest.java
+++ b/src/test/java/com/Flaground/backend/module/member/SleepingRepositoryTest.java
@@ -1,22 +1,42 @@
 package com.Flaground.backend.module.member;
 
 import com.Flaground.backend.common.RepositoryTest;
+import com.Flaground.backend.module.member.domain.Avatar;
+import com.Flaground.backend.module.member.domain.Member;
 import com.Flaground.backend.module.member.domain.Sleeping;
+import com.Flaground.backend.module.member.domain.enums.MemberStatus;
+import com.Flaground.backend.module.member.domain.repository.MemberRepository;
 import com.Flaground.backend.module.member.domain.repository.SleepingRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SleepingRepositoryTest extends RepositoryTest {
+class SleepingRepositoryTest extends RepositoryTest {
     @Autowired
     private SleepingRepository sleepingRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Sleeping sleeping;
+    private Member member;
+
+    @BeforeEach
+    void setup() {
+        final String loginId = "gmlwh124";
+        final String email = "gmlwh124@suwon.ac.kr";
+
+        Avatar avatar = Avatar.builder().build();
+        member = memberRepository.save(Member.builder().loginId(loginId).email(email).avatar(avatar).build());
+        sleeping = sleepingRepository.save(Sleeping.of(member));
+    }
 
     @Test
     void 휴면유저_삭제_쿼리_테스트() {
         // given
         final String loginId = "gmlwh124";
-        sleepingRepository.save(Sleeping.builder().loginId(loginId).build());
 
         // when
         sleepingRepository.deleteByLoginId(loginId);
@@ -24,5 +44,22 @@ public class SleepingRepositoryTest extends RepositoryTest {
         // then
         Sleeping sleeping = sleepingRepository.findByLoginId(loginId).orElse(null);
         assertThat(sleeping).isNull();
+    }
+
+    @Test
+    void 휴면유저_활성화_테스트() {
+        // given
+        final String loginId = "gmlwh124";
+        final String email = "gmlwh124@suwon.ac.kr";
+        member.deactivate();
+
+        // when
+        sleepingRepository.findByLoginId(loginId)
+                .ifPresent(Sleeping::reactivate);
+
+        // then
+        assertThat(member.getLoginId()).isEqualTo(loginId);
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.NORMAL);
     }
 }

--- a/src/test/java/com/Flaground/backend/module/post/PostControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/post/PostControllerTest.java
@@ -33,6 +33,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,7 +46,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class PostControllerTest extends IntegrationTest {
+@Transactional
+class PostControllerTest extends IntegrationTest {
     private static final String BASE_URI = "/posts";
 
     @Autowired
@@ -107,12 +109,12 @@ public class PostControllerTest extends IntegrationTest {
         }
 
         @Test
-        public void 비회원_게시글_가져오기_성공() throws Exception {
+        void 비회원_게시글_가져오기_성공() throws Exception {
             // given
+            clearSecurityContext();
             final String reply = "reply";
             final int viewCount = post.getViewCount();
             post.addReply(Reply.of(member, post.getId(), reply));
-            clearSecurityContext();
 
             // when
             mockMvc.perform(get(uri)

--- a/src/test/java/com/Flaground/backend/module/post/reply/ReplyControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/post/reply/ReplyControllerTest.java
@@ -13,6 +13,7 @@ import com.Flaground.backend.module.post.domain.Reply;
 import com.Flaground.backend.module.post.domain.repository.LikeRepository;
 import com.Flaground.backend.module.post.domain.repository.PostRepository;
 import com.Flaground.backend.module.post.domain.repository.ReplyRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,7 +38,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ReplyControllerTest extends IntegrationTest {
+@Transactional
+class ReplyControllerTest extends IntegrationTest {
     private static final String BASE_URI = "/posts";
 
     @Autowired

--- a/src/test/java/com/Flaground/backend/module/report/ReportControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/report/ReportControllerTest.java
@@ -13,7 +13,10 @@ import com.Flaground.backend.module.post.domain.repository.ReplyRepository;
 import com.Flaground.backend.module.report.controller.dto.request.ContentReportRequest;
 import com.Flaground.backend.module.report.controller.dto.request.MemberReportRequest;
 import com.Flaground.backend.module.report.controller.mapper.ReportMapper;
-import com.Flaground.backend.module.report.domain.*;
+import com.Flaground.backend.module.report.domain.MemberReport;
+import com.Flaground.backend.module.report.domain.PostReport;
+import com.Flaground.backend.module.report.domain.ReplyReport;
+import com.Flaground.backend.module.report.domain.Report;
 import com.Flaground.backend.module.report.domain.enums.ReportCategory;
 import com.Flaground.backend.module.report.domain.enums.ReportType;
 import com.Flaground.backend.module.report.domain.repository.ReportRepository;
@@ -40,7 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ReportControllerTest extends IntegrationTest {
+class ReportControllerTest extends IntegrationTest {
     private static final String BASE_URI = "/reports";
 
     @Autowired
@@ -83,7 +86,8 @@ public class ReportControllerTest extends IntegrationTest {
 
     @AfterEach
     void cleanUp() {
-        reportRepository.deleteAll();
+        reportRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
     }
 
     @Nested
@@ -92,7 +96,7 @@ public class ReportControllerTest extends IntegrationTest {
         private final ReportCategory category = ReportCategory.욕설;
         private final String detailReason = "test";
         private final ReportType reportType = ReportType.MEMBER;
-        private MemberReportRequest request = MemberReportRequest.builder()
+        private final MemberReportRequest request = MemberReportRequest.builder()
                 .loginId(loginId)
                 .reportCategory(category)
                 .detailExplanation(detailReason)
@@ -158,6 +162,11 @@ public class ReportControllerTest extends IntegrationTest {
                     .build();
         }
 
+        @AfterEach
+        void cleanPost() {
+            postRepository.deleteAllInBatch();
+        }
+
         @Test
         void 게시글_신고_성공() throws Exception {
             // given
@@ -218,6 +227,12 @@ public class ReportControllerTest extends IntegrationTest {
                     .reportCategory(category)
                     .detailExplanation(detailReason)
                     .build();
+        }
+
+        @AfterEach
+        void cleanPostAndReply() {
+            replyRepository.deleteAllInBatch();
+            postRepository.deleteAllInBatch();
         }
 
         @Test

--- a/src/test/java/com/Flaground/backend/module/report/ReportControllerTest.java
+++ b/src/test/java/com/Flaground/backend/module/report/ReportControllerTest.java
@@ -13,11 +13,11 @@ import com.Flaground.backend.module.post.domain.repository.ReplyRepository;
 import com.Flaground.backend.module.report.controller.dto.request.ContentReportRequest;
 import com.Flaground.backend.module.report.controller.dto.request.MemberReportRequest;
 import com.Flaground.backend.module.report.controller.mapper.ReportMapper;
-import com.Flaground.backend.module.report.domain.Report;
+import com.Flaground.backend.module.report.domain.*;
 import com.Flaground.backend.module.report.domain.enums.ReportCategory;
-import com.Flaground.backend.module.report.domain.ReportData;
 import com.Flaground.backend.module.report.domain.enums.ReportType;
 import com.Flaground.backend.module.report.domain.repository.ReportRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -58,23 +58,32 @@ public class ReportControllerTest extends IntegrationTest {
     @Autowired
     private ReportMapper reportMapper;
 
-    private Member member;
+    private Member reporter;
+    private Member reported;
 
     @BeforeEach
     void testSetup() {
+        final String loginId = "gmlwh124";
         final String email = "gmlwh124@suwon.ac.kr";
         final String nickname = "john";
         final Role role = Role.ROLE_USER;
 
         Avatar avatar = Avatar.builder().nickname(nickname).build();
 
-        member = memberRepository.save(Member.builder()
+        reporter = memberRepository.save(Member.builder()
                 .email(email)
                 .avatar(avatar)
                 .role(role)
                 .build());
 
-        setSecurityContext(member);
+        reported = memberRepository.save(Member.builder().loginId(loginId).build());
+
+        setSecurityContext(reporter);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        reportRepository.deleteAll();
     }
 
     @Nested
@@ -84,20 +93,14 @@ public class ReportControllerTest extends IntegrationTest {
         private final String detailReason = "test";
         private final ReportType reportType = ReportType.MEMBER;
         private MemberReportRequest request = MemberReportRequest.builder()
-                .target(loginId)
+                .loginId(loginId)
                 .reportCategory(category)
                 .detailExplanation(detailReason)
                 .build();
         private final String uri = BASE_URI + "/member";
-        private Member reported;
-
-        @BeforeEach
-        private void testSetup() {
-            reported = memberRepository.save(Member.builder().loginId(loginId).build());
-        }
 
         @Test
-        public void 멤버_신고_성공() throws Exception {
+        void 멤버_신고_성공() throws Exception {
             // given
 
             // when
@@ -108,20 +111,18 @@ public class ReportControllerTest extends IntegrationTest {
                     .andDo(print());
 
             // then
-            ReportData<String> reportData = reportMapper.mapFrom(request);
-            assertThat(reportData.getReportType()).isEqualTo(reportType);
-
-            Report report = reportRepository.findAll().get(0);
-            assertThat(report.getReporter()).isEqualTo(member.getId());
-            assertThat(report.getReported()).isEqualTo(reported.getId());
-            assertThat(report.getReportCategory()).isEqualTo(category);
-            assertThat(report.getDetailExplanation()).isEqualTo(detailReason);
+            MemberReport report = (MemberReport) reportRepository.findAll().get(0);
+            assertThat(report.getLoginId()).isEqualTo(loginId);
+            assertThat(report.getReportInfo().getReportType()).isEqualTo(reportType);
+            assertThat(report.getReportInfo().getReportCategory()).isEqualTo(category);
+            assertThat(report.getReportInfo().getDetailExplanation()).isEqualTo(detailReason);
         }
 
         @Test
-        public void 멤버_신고_실패() throws Exception {
+        void 멤버_신고_실패() throws Exception {
             // given
-            reportRepository.save(Report.member(member.getId(), reported.getId(), reportMapper.mapFrom(request)));
+            Report report = MemberReport.of(reporter.getId(), reported.getId(), reportMapper.mapFrom(request));
+            reportRepository.save(report);
 
             // when
             ResultActions resultActions = mockMvc.perform(post(uri)
@@ -142,13 +143,13 @@ public class ReportControllerTest extends IntegrationTest {
         private final ReportCategory category = ReportCategory.도배;
         private final String detailReason = "test";
         private final ReportType reportType = ReportType.POST;
-        private final String uri = BASE_URI + "/content";
+        private final String uri = BASE_URI + "/post";
         private Post post;
         private ContentReportRequest request;
 
         @BeforeEach
         void testSetup() {
-            post = postRepository.save(Post.builder().build());
+            post = postRepository.save(Post.builder().member(reported).build());
             request = ContentReportRequest.builder()
                     .target(post.getId())
                     .reportType(reportType)
@@ -158,7 +159,7 @@ public class ReportControllerTest extends IntegrationTest {
         }
 
         @Test
-        public void 게시글_신고_성공() throws Exception {
+        void 게시글_신고_성공() throws Exception {
             // given
 
             // when
@@ -169,21 +170,19 @@ public class ReportControllerTest extends IntegrationTest {
                     .andDo(print());
 
             // then
-            ReportData<Long> reportData = reportMapper.mapFrom(request);
-            assertThat(reportData.getTarget()).isEqualTo(post.getId());
-            assertThat(reportData.getReportType()).isEqualTo(reportType);
-            assertThat(reportData.getReportCategory()).isEqualTo(category);
-            assertThat(reportData.getDetailExplanation()).isEqualTo(detailReason);
-
-            Report report = reportRepository.findAll().get(0);
-            assertThat(report.getReporter()).isEqualTo(member.getId());
-            assertThat(report.getReported()).isEqualTo(post.getId());
+            PostReport report = (PostReport) reportRepository.findAll().get(0);
+            assertThat(report.getPostId()).isEqualTo(post.getId());
+            assertThat(report.getReportInfo().getReportType()).isEqualTo(reportType);
+            assertThat(report.getReportInfo().getReportCategory()).isEqualTo(category);
+            assertThat(report.getReportInfo().getDetailExplanation()).isEqualTo(detailReason);
         }
 
         @Test
-        public void 게시글_신고_실패() throws Exception {
+        void 게시글_신고_실패() throws Exception {
             // given
-            reportRepository.save(Report.content(member.getId(), reportMapper.mapFrom(request)));
+            final String board = "자유게시판";
+            Report report = PostReport.of(reporter.getId(), reported.getId(), board, reportMapper.mapFrom(request));
+            reportRepository.save(report);
 
             // when
             ResultActions resultActions = mockMvc.perform(post(uri)
@@ -204,13 +203,15 @@ public class ReportControllerTest extends IntegrationTest {
         private final ReportCategory category = ReportCategory.홍보;
         private final String detailReason = "test";
         private final ReportType reportType = ReportType.REPLY;
-        private final String uri = BASE_URI + "/content";
+        private final String uri = BASE_URI + "/reply";
+        private Post post;
         private Reply reply;
         private ContentReportRequest request;
 
         @BeforeEach
         void testSetup() {
-            reply = replyRepository.save(Reply.builder().build());
+            post = postRepository.save(Post.builder().member(reporter).build());
+            reply = replyRepository.save(Reply.of(reported, post.getId(), "test"));
             request = ContentReportRequest.builder()
                     .target(reply.getId())
                     .reportType(reportType)
@@ -231,21 +232,19 @@ public class ReportControllerTest extends IntegrationTest {
                     .andDo(print());
 
             // then
-            ReportData<Long> reportData = reportMapper.mapFrom(request);
-            assertThat(reportData.getTarget()).isEqualTo(reply.getId());
-            assertThat(reportData.getReportType()).isEqualTo(reportType);
-            assertThat(reportData.getReportCategory()).isEqualTo(category);
-            assertThat(reportData.getDetailExplanation()).isEqualTo(detailReason);
-
-            Report report = reportRepository.findAll().get(0);
-            assertThat(report.getReporter()).isEqualTo(member.getId());
-            assertThat(report.getReported()).isEqualTo(reply.getId());
+            ReplyReport report = (ReplyReport) reportRepository.findAll().get(0);
+            assertThat(report.getPostId()).isEqualTo(post.getId());
+            assertThat(report.getReplyId()).isEqualTo(reply.getId());
+            assertThat(report.getReportInfo().getReportType()).isEqualTo(reportType);
+            assertThat(report.getReportInfo().getReportCategory()).isEqualTo(category);
+            assertThat(report.getReportInfo().getDetailExplanation()).isEqualTo(detailReason);
         }
 
         @Test
         public void 댓글_신고_실패() throws Exception {
             // given
-            reportRepository.save(Report.content(member.getId(), reportMapper.mapFrom(request)));
+            Report report = ReplyReport.of(reporter.getId(), reported.getId(), post.getId(), reportMapper.mapFrom(request));
+            reportRepository.save(report);
 
             // when
             ResultActions resultActions = mockMvc.perform(post(uri)

--- a/src/test/java/com/Flaground/backend/module/report/ReportRepositoryTest.java
+++ b/src/test/java/com/Flaground/backend/module/report/ReportRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.Flaground.backend.module.report;
+
+import com.Flaground.backend.common.RepositoryTest;
+import com.Flaground.backend.module.member.domain.Member;
+import com.Flaground.backend.module.member.domain.repository.MemberRepository;
+import com.Flaground.backend.module.post.domain.Post;
+import com.Flaground.backend.module.post.domain.Reply;
+import com.Flaground.backend.module.post.domain.repository.PostRepository;
+import com.Flaground.backend.module.post.domain.repository.ReplyRepository;
+import com.Flaground.backend.module.report.controller.dto.response.ReportResponse;
+import com.Flaground.backend.module.report.domain.*;
+import com.Flaground.backend.module.report.domain.enums.ReportType;
+import com.Flaground.backend.module.report.domain.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReportRepositoryTest extends RepositoryTest {
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private ReplyRepository replyRepository;
+
+    private Member reporter;
+    private Member reported;
+    private Post post;
+    private Reply reply;
+
+    @BeforeEach
+    void setup() {
+        final String loginId = "gmlwh124";
+        reporter = memberRepository.save(Member.builder().build());
+        reported = memberRepository.save(Member.builder().loginId(loginId).build());
+        post = postRepository.save(Post.builder().member(reported).build());
+        reply = replyRepository.save(Reply.of(reported, post.getId(), "test"));
+    }
+
+    @Test
+    void 신고이력_가져오기_테스트() {
+        // given
+        Report memberReport = MemberReport.builder()
+                .reporter(reporter.getId())
+                .reported(reported.getId())
+                .reportInfo(ReportInfo.builder().reportType(ReportType.MEMBER).build())
+                .build();
+
+        Report postReport = PostReport.builder()
+                .reporter(reporter.getId())
+                .reported(reported.getId())
+                .reportInfo(ReportInfo.builder().reportType(ReportType.POST).build())
+                .build();
+
+        Report replyReport = ReplyReport.builder()
+                .reporter(reporter.getId())
+                .reported(reported.getId())
+                .reportInfo(ReportInfo.builder().reportType(ReportType.REPLY).build())
+                .build();
+
+        reportRepository.saveAll(List.of(memberReport, postReport, replyReport));
+
+        // when
+        ReportResponse reports = reportRepository.getReports();
+
+        // then
+        assertThat(reports.getMemberReportResponses().size()).isEqualTo(1);
+        assertThat(reports.getPostReportResponses().size()).isEqualTo(1);
+        assertThat(reports.getReplyReportResponses().size()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
 - 신고 엔티티 분리 (요구사항이 다름)
 - 신고 처리하기 구현 (컨트롤러 미적용)
 - 로그인 실패 핸들링 구현 (계정 잠금, 실패 카운팅, 실패 예외 세분화)

### 그 외
 - 게시판 검색 오류 수정 (검색 기간이 반대로 적용)
 - 계정 활성화 시 불필요한 쿼리 제거
 - 인프라 서비스 추상화
 - 통합테스트 트랜잭션 제거